### PR TITLE
Get extension id from url instead evaluating expression in the contex…

### DIFF
--- a/wallets-testing/browser/browser.context.service.ts
+++ b/wallets-testing/browser/browser.context.service.ts
@@ -78,9 +78,7 @@ export class BrowserContextService {
         if (background === undefined)
           background = await this.browserContext.waitForEvent('backgroundpage');
         this.extensionPage = background;
-        this.extensionId = await this.extensionPage.evaluate(
-          'chrome.runtime.id',
-        );
+        this.extensionId = background.url().split('/')[2];
         break;
       }
       case Manifest.v3: {


### PR DESCRIPTION
Metamask enables security things https://github.com/MetaMask/metamask-extension/pull/17276 that not allows executing global objects in the extension context
Actually we use it only for getting extension id but we able to get it simply by URL parsing
