### PR TITLE
Fix some wallet problems

### DIFF
--- a/packages/wallets/src/exodus/exodus.page.ts
+++ b/packages/wallets/src/exodus/exodus.page.ts
@@ -56,18 +56,13 @@ export class ExodusPage implements WalletPage {
       await this.page.click('text=I Have A Wallet');
       await this.page.fill('input[type="text"]', this.config.SECRET_PHRASE);
       await this.page.click(':nth-match(:text("Restore"), 2)');
-      await this.page.fill('input[type=password]', this.config.PASSWORD);
-      await this.page.click('text=Next');
-      await this.page.fill('input[type=password]', this.config.PASSWORD);
-      await this.page.click(
-        'div[data-testid="exodusmovement.exodus:id/button-next"]',
-      );
       await this.page.waitForSelector('text=Continue');
     });
   }
 
   async connectWallet(page: Page) {
     await test.step('Connect wallet', async () => {
+      await page.waitForTimeout(2000);
       await page.click(':nth-match(:text("Connect"), 3)');
       await page.close();
     });

--- a/packages/wallets/src/phantom/phantom.page.ts
+++ b/packages/wallets/src/phantom/phantom.page.ts
@@ -28,6 +28,9 @@ export class PhantomPage implements WalletPage {
       this.page = await this.browserContext.newPage();
       await this.page.goto(this.extensionUrl + '/onboarding.html');
       if (!this.page) throw "Page isn't ready";
+      await this.page.waitForSelector(
+        'button:has-text("I already have a wallet")',
+      );
       const firstTime =
         (await this.page
           .locator('button:has-text("I already have a wallet")')

--- a/packages/wallets/src/taho/taho.constants.ts
+++ b/packages/wallets/src/taho/taho.constants.ts
@@ -4,7 +4,7 @@ export const TAHO_COMMON_CONFIG: CommonWalletConfig = {
   WALLET_NAME: 'taho',
   RPC_URL_PATTERN: 'https://mainnet.infura.io/v3/**',
   STORE_EXTENSION_ID: 'eajafomhmkipbjmfmhebemolkcicgfmd',
-  CONNECT_BUTTON_NAME: 'Tally',
+  CONNECT_BUTTON_NAME: 'Taho',
   SIMPLE_CONNECT: false,
   EXTENSION_START_PATH: '/popup.html',
 };


### PR DESCRIPTION
Taho
- Set new connect button name to "Taho:

Exodus
- Exodus has excluded password init for setup(). 
- Added timeout for wallet connect confirmation since it`s failed sometimes due to fast click on pop-up(IMO)