### PR TITLE
Slope wallet connect test init

### DIFF
--- a/packages/extensions/src/extension.service.ts
+++ b/packages/extensions/src/extension.service.ts
@@ -28,6 +28,25 @@ export class ExtensionService {
     return this.idToExtension[id];
   }
 
+  // Check "persistent" tag from extension manifest for Slope wallet, since it`s false by default.
+  // The "persistent": false tag in the manifest.json file of a Google Chrome extension indicates
+  // that the extension should not run continuously and remain active throughout the entire time
+  // the browser is being used. Instead, the extension will only run in response to certain events,
+  // such as a user clicking on the extension button or visiting a specific web page.
+  async checkPersistent(extensionDir: string, walletName: string) {
+    if (walletName === 'slope') {
+      const content = await fs.readFile(extensionDir + '/manifest.json');
+      const manifestObj = JSON.parse(String(content));
+      if (manifestObj.background.persistent === false) {
+        manifestObj.background.persistent = true;
+        await fs.writeFile(
+          extensionDir + '/manifest.json',
+          JSON.stringify(manifestObj, null, 2),
+        );
+      }
+    }
+  }
+
   async getManifestVersion(extensionDir: string): Promise<Manifest> {
     const content = await fs.readFile(extensionDir + '/manifest.json');
     return JSON.parse(String(content)).manifest_version;

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -10,3 +10,4 @@ export * from './taho';
 export * from './exodus';
 export * from './gamestop';
 export * from './xdefi';
+export * from './slope';

--- a/packages/wallets/src/slope/index.ts
+++ b/packages/wallets/src/slope/index.ts
@@ -1,0 +1,2 @@
+export * from './slope.constants';
+export * from './slope.page';

--- a/packages/wallets/src/slope/slope.constants.ts
+++ b/packages/wallets/src/slope/slope.constants.ts
@@ -1,0 +1,10 @@
+import { CommonWalletConfig } from '../wallets.constants';
+
+export const SLOPE_COMMON_CONFIG: CommonWalletConfig = {
+  WALLET_NAME: 'slope',
+  RPC_URL_PATTERN: '',
+  STORE_EXTENSION_ID: 'pocmplpaccanhmnllbbkpgfliimjljgo',
+  CONNECT_BUTTON_NAME: 'Slope',
+  SIMPLE_CONNECT: false,
+  EXTENSION_START_PATH: '/pop-up.html',
+};

--- a/packages/wallets/src/slope/slope.page.ts
+++ b/packages/wallets/src/slope/slope.page.ts
@@ -1,0 +1,149 @@
+import { WalletConfig } from '../wallets.constants';
+import { WalletPage } from '../wallet.page';
+import { test, BrowserContext, Page } from '@playwright/test';
+
+export class SlopePage implements WalletPage {
+  page: Page | undefined;
+
+  constructor(
+    private browserContext: BrowserContext,
+    private extensionUrl: string,
+    public config: WalletConfig,
+  ) {}
+
+  async navigate() {
+    await test.step('Navigate to Slope', async () => {
+      this.page = await this.browserContext.newPage();
+      await this.page.goto(
+        this.extensionUrl + this.config.COMMON.EXTENSION_START_PATH,
+      );
+      await this.page.reload();
+      await this.page.waitForTimeout(1000);
+      await this.closePopover();
+      await this.unlock();
+    });
+  }
+
+  async setup() {
+    await test.step('Setup', async () => {
+      this.page = await this.browserContext.newPage();
+      await this.page.goto(this.extensionUrl + '/index.html#/');
+      if (!this.page) throw "Page isn't ready";
+      await this.page.waitForSelector('button:has-text("Import Your Wallet")');
+      const firstTime =
+        (await this.page.locator('text=Import Your Wallet').count()) > 0;
+      if (firstTime) await this.firstTimeSetup();
+    });
+  }
+
+  async unlock() {
+    await test.step('Unlock', async () => {
+      if (!this.page) throw "Page isn't ready";
+      if (
+        (await this.page
+          .locator('input[placeholder="Please enter..."]')
+          .count()) > 0
+      ) {
+        await this.page.fill(
+          'input[placeholder="Please enter..."]',
+          this.config.PASSWORD,
+        );
+        await this.page.click('button:has-text("Unlock")');
+      }
+    });
+  }
+
+  async importTokens(token: string) {
+    await test.step('Import token', async () => {
+      await this.navigate();
+      if (!this.page) throw "Page isn't ready";
+      await this.page.click("text='import tokens'");
+      await this.page.click('text=Custom token');
+      await this.page.type('id=custom-address', token);
+    });
+  }
+
+  async closePopover() {
+    await test.step('Close popover if exists', async () => {
+      if (!this.page) throw "Page isn't ready";
+      const popover =
+        (await this.page.getByTestId('popover-close').count()) > 0;
+      if (popover) await this.page.click('data-testid=popover-close');
+    });
+  }
+
+  async firstTimeSetup() {
+    await test.step('First time setup', async () => {
+      if (!this.page) throw "Page isn't ready";
+      await this.page.click('.van-checkbox__icon');
+      await this.page.click('text=Import Your Wallet');
+      await this.page.fill('textarea', this.config.SECRET_PHRASE);
+      await this.page.click('text=Next');
+      const inputs = await this.page.locator('input[type=password]');
+      await inputs.nth(0).fill(this.config.PASSWORD);
+      await inputs.nth(1).fill(this.config.PASSWORD);
+      await this.page.click("button[type='Submit']");
+      await this.page.waitForSelector("text='You're all done !'");
+    });
+  }
+
+  async addNetwork(
+    networkName: string,
+    networkUrl: string,
+    chainId: number,
+    tokenSymbol: string,
+  ) {
+    await test.step('Add network', async () => {
+      if (!this.page) throw "Page isn't ready";
+      await this.navigate();
+      await this.page.click('.account-menu__icon');
+      await this.page.click('text=Settings');
+      await this.page.click("text='Networks'");
+      await this.page.click('text=Add a network');
+      await this.page.click("a :has-text('Add a network manually')");
+      await this.page.fill(
+        ".form-field :has-text('Network Name') >> input",
+        networkName,
+      );
+      await this.page.fill(
+        ".form-field :has-text('New RPC URL') >> input",
+        networkUrl,
+      );
+      await this.page.fill(
+        ".form-field :has-text('Chain ID') >> input",
+        String(chainId),
+      );
+      await this.page.fill(
+        ".form-field :has-text('Currency symbol') >> input",
+        tokenSymbol,
+      );
+      await this.page.click('text=Save');
+      await this.navigate();
+    });
+  }
+
+  async connectWallet(page: Page) {
+    await test.step('Connect wallet', async () => {
+      await page.click('button:has-text("Connect")');
+    });
+  }
+
+  async confirmTx(page: Page) {
+    await test.step('Confirm TX', async () => {
+      await page.click('button:has-test("Approve")');
+    });
+  }
+
+  // eslint-disable-next-line
+  async assertTxAmount(page: Page, expectedAmount: string) {
+  }
+
+  // eslint-disable-next-line
+  async approveTokenTx(page: Page) {}
+
+  // eslint-disable-next-line
+  async assertReceiptAddress(page: Page, expectedAddress: string) {}
+
+  // eslint-disable-next-line
+  async importKey(key: string) {}
+}

--- a/wallets-testing/browser/browser.constants.ts
+++ b/wallets-testing/browser/browser.constants.ts
@@ -9,6 +9,7 @@ import {
   TahoPage,
   GameStopPage,
   XdefiPage,
+  SlopePage,
 } from '@lidofinance/wallets-testing-wallets';
 import {
   EthereumPage,
@@ -29,6 +30,7 @@ export const WALLET_PAGES = {
   taho: TahoPage,
   gamestop: GameStopPage,
   xdefi: XdefiPage,
+  slope: SlopePage,
 };
 
 export const WIDGET_PAGES = {

--- a/wallets-testing/browser/browser.service.ts
+++ b/wallets-testing/browser/browser.service.ts
@@ -81,6 +81,10 @@ export class BrowserService {
       await this.extensionService.getExtensionDirFromId(
         commonWalletConfig.STORE_EXTENSION_ID,
       );
+    await this.extensionService.checkPersistent(
+      walletConfig.EXTENSION_PATH,
+      commonWalletConfig.WALLET_NAME,
+    );
     await this.browserContextService.setup(
       walletConfig,
       this.widgetConfig.nodeUrl,

--- a/wallets-testing/test/widgets/solana.spec.ts
+++ b/wallets-testing/test/widgets/solana.spec.ts
@@ -6,6 +6,7 @@ import {
   COINBASE_COMMON_CONFIG,
   COIN98_COMMON_CONFIG,
   EXODUS_COMMON_CONFIG,
+  SLOPE_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import { SOLANA_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
@@ -42,6 +43,11 @@ test.describe('Solana', () => {
 
   test(`Exodus connect`, async () => {
     await browserService.setup(EXODUS_COMMON_CONFIG, SOLANA_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Slope connect`, async () => {
+    await browserService.setup(SLOPE_COMMON_CONFIG, SOLANA_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 


### PR DESCRIPTION
Chrome wallet extensions come with a manifest.json file that includes various parameters, and developers can use either manifest V2 or V3 to build extensions. Our automated wallets primarily use manifest V2, with the exception of Trust wallet which uses V3. From an automation standpoint, both versions are only used for detecting the extension ID in the browser after the page has loaded, which is done via the setExtensionVars() function in browser.context.service.ts.

One important parameter in the manifest.json file is "persistent", which determines whether the extension should continue running in the background even after the user has closed all Chrome windows. If set to true, the extension will remain active and can perform tasks like checking for updates or monitoring a website for changes. If set to false, the extension will be unloaded when the user closes all Chrome windows.
![image](https://user-images.githubusercontent.com/19698566/235111084-1f2b0b59-43e1-4b6b-a168-1aa012a96f68.png)


Currently, all of our extensions with manifest V2 have "persistent": true, but the Slope wallet's manifest has it set to false by default. As a result, our setExtensionVars() function cannot detect the Slope extension in the browser and cannot open it.

Our current solution is to manually edit the "persistent" property for the Slope wallet before calling initBrowserContext(), which allows the Slope extension to run in the background and enables the setExtensionVars() function to work properly.