### PR TITLE
fix taho-metamask pop-up

### DIFF
--- a/packages/wallets/src/taho/taho.page.ts
+++ b/packages/wallets/src/taho/taho.page.ts
@@ -68,6 +68,8 @@ export class TahoPage implements WalletPage {
 
   async connectWallet(page: Page) {
     await test.step('Connect wallet', async () => {
+      await page.locator('button').nth(3).click();
+      await page.locator('button').nth(1).click();
       await page.click('button:has-text("Connect")');
       await page.close();
     });


### PR DESCRIPTION
Taho added some metamask conflict  pop-up(but in test there is no metamask installed)