### PR TITLE
BitKeep wallet init

### DIFF
--- a/packages/wallets/src/bitKeep/bitKeep.constants.ts
+++ b/packages/wallets/src/bitKeep/bitKeep.constants.ts
@@ -1,0 +1,10 @@
+import { CommonWalletConfig } from '../wallets.constants';
+
+export const BItKEEP_COMMON_CONFIG: CommonWalletConfig = {
+  WALLET_NAME: 'bitKeep',
+  RPC_URL_PATTERN: '',
+  STORE_EXTENSION_ID: 'jiidiaalihmmhddjgbnbgdfflelocpak',
+  CONNECT_BUTTON_NAME: 'BitKeep',
+  SIMPLE_CONNECT: false,
+  EXTENSION_START_PATH: '/welcome.html',
+};

--- a/packages/wallets/src/bitKeep/bitKeep.page.ts
+++ b/packages/wallets/src/bitKeep/bitKeep.page.ts
@@ -25,7 +25,7 @@ export class BitKeepPage implements WalletPage {
 
   async setup() {
     await test.step('Setup', async () => {
-      // added explicit route to /onboarding due to unexpected first time route from /home.html to /onboarding - page is close
+      // added explicit route to /welcome.html due to unexpected first time route from /home.html to /welcome.html - page is close
       this.page = await this.browserContext.newPage();
       await this.page.goto(this.extensionUrl + '/welcome.html');
       await this.page.waitForSelector('text=Welcome to Bitget Wallet');

--- a/packages/wallets/src/bitKeep/bitKeep.page.ts
+++ b/packages/wallets/src/bitKeep/bitKeep.page.ts
@@ -1,0 +1,100 @@
+import { WalletConfig } from '../wallets.constants';
+import { WalletPage } from '../wallet.page';
+import { test, BrowserContext, Page } from '@playwright/test';
+
+export class BitKeepPage implements WalletPage {
+  page: Page | undefined;
+
+  constructor(
+    private browserContext: BrowserContext,
+    private extensionUrl: string,
+    public config: WalletConfig,
+  ) {}
+
+  async navigate() {
+    await test.step('Navigate to BitKeep', async () => {
+      this.page = await this.browserContext.newPage();
+      await this.page.goto(
+        this.extensionUrl + this.config.COMMON.EXTENSION_START_PATH,
+      );
+      await this.page.reload();
+      await this.page.waitForTimeout(1000);
+      await this.unlock();
+    });
+  }
+
+  async setup() {
+    await test.step('Setup', async () => {
+      // added explicit route to /onboarding due to unexpected first time route from /home.html to /onboarding - page is close
+      this.page = await this.browserContext.newPage();
+      await this.page.goto(this.extensionUrl + '/welcome.html');
+      await this.page.waitForSelector('text=Welcome to Bitget Wallet');
+      const firstTime =
+        (await this.page
+          .locator("button:has-text('Import a wallet')")
+          .count()) > 0;
+      if (firstTime) await this.firstTimeSetup();
+    });
+  }
+
+  async unlock() {
+    await test.step('Unlock', async () => {
+      if (!this.page) throw "Page isn't ready";
+      if ((await this.page.locator('id=password').count()) > 0) {
+        await this.page.fill('id=password', this.config.PASSWORD);
+        await this.page.click('text=Unlock');
+      }
+    });
+  }
+
+  async firstTimeSetup() {
+    await test.step('First time setup', async () => {
+      if (!this.page) throw "Page isn't ready";
+      await this.page.click("button:has-text('Import a wallet')");
+      await this.page.fill(
+        "input[placeholder='Minimum 6 characters']",
+        this.config.PASSWORD,
+      );
+      await this.page.fill(
+        "input[placeholder='Enter the password again']",
+        this.config.PASSWORD,
+      );
+      await this.page.click("button:has-text('Next')");
+      await this.page.fill(
+        'textarea[id=outlined-multiline-static]',
+        this.config.SECRET_PHRASE,
+      );
+      await this.page.click("button:has-text('Confirm')");
+      await this.page.waitForSelector('text=Wallet successfully imported');
+    });
+  }
+
+  async connectWallet(page: Page) {
+    await test.step('Connect wallet', async () => {
+      await page.waitForTimeout(1000);
+      await page.click("button:has-text('Connect')");
+      await page.close();
+    });
+  }
+
+  // eslint-disable-next-line
+    async addNetwork(networkName: string, networkUrl: string, chainId: number, tokenSymbol: string) {}
+
+  // eslint-disable-next-line
+  async importKey(key: string) {}
+
+  // eslint-disable-next-line
+  async assertTxAmount(page: Page, expectedAmount: string) {}
+
+  // eslint-disable-next-line
+  async confirmTx(page: Page) {}
+
+  // eslint-disable-next-line
+  async approveTokenTx(page: Page) {}
+
+  // eslint-disable-next-line
+  async useDefaultToApprove(page: Page) {}
+
+  // eslint-disable-next-line
+  async assertReceiptAddress(page: Page, expectedAddress: string) {}
+}

--- a/packages/wallets/src/bitKeep/index.ts
+++ b/packages/wallets/src/bitKeep/index.ts
@@ -1,0 +1,2 @@
+export * from './bitKeep.constants';
+export * from './bitKeep.page';

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -11,3 +11,4 @@ export * from './exodus';
 export * from './gamestop';
 export * from './xdefi';
 export * from './okx';
+export * from './bitKeep';

--- a/wallets-testing/browser/browser.constants.ts
+++ b/wallets-testing/browser/browser.constants.ts
@@ -31,7 +31,8 @@ export const WALLET_PAGES = {
   taho: TahoPage,
   gamestop: GameStopPage,
   xdefi: XdefiPage,
-  okx: OkxPage
+  okx: OkxPage,
+  bitKeep: BitKeepPage,
 };
 
 export const WIDGET_PAGES = {

--- a/wallets-testing/browser/browser.constants.ts
+++ b/wallets-testing/browser/browser.constants.ts
@@ -9,7 +9,8 @@ import {
   TahoPage,
   GameStopPage,
   XdefiPage,
-  OkxPage
+  OkxPage,
+  BitKeepPage,
 } from '@lidofinance/wallets-testing-wallets';
 import {
   EthereumPage,
@@ -30,7 +31,8 @@ export const WALLET_PAGES = {
   taho: TahoPage,
   gamestop: GameStopPage,
   xdefi: XdefiPage,
-  okx: OkxPage
+  okx: OkxPage,
+  bitKeep: BitKeepPage,
 };
 
 export const WIDGET_PAGES = {

--- a/wallets-testing/browser/browser.context.service.ts
+++ b/wallets-testing/browser/browser.context.service.ts
@@ -3,7 +3,10 @@ import { BrowserContext, chromium, Page } from 'playwright';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { WalletConfig } from '@lidofinance/wallets-testing-wallets';
+import {
+  CommonWalletConfig,
+  WalletConfig,
+} from '@lidofinance/wallets-testing-wallets';
 import { EthereumNodeService } from '@lidofinance/wallets-testing-nodes';
 import {
   ExtensionService,
@@ -25,13 +28,13 @@ export class BrowserContextService {
     private extensionService: ExtensionService,
   ) {}
 
-  async setup(walletConfig: WalletConfig, nodeUrl: string) {
+  async setup(walletName: string, walletConfig: WalletConfig, nodeUrl: string) {
     this.walletConfig = walletConfig;
     this.nodeUrl = nodeUrl;
-    await this.initBrowserContext();
+    await this.initBrowserContext(walletName);
   }
 
-  async initBrowserContext() {
+  async initBrowserContext(walletName: string) {
     this.logger.debug('Starting a new browser context');
     const browserContextPath = await fs.mkdtemp(os.tmpdir() + path.sep);
     this.browserContext = await chromium.launchPersistentContext(
@@ -59,7 +62,10 @@ export class BrowserContextService {
       this.browserContextPaths.push(browserContextPath);
       this.logger.debug('Browser context closed');
     });
-    await this.setExtensionVars(this.walletConfig.COMMON.EXTENSION_START_PATH);
+    await this.setExtensionVars(
+      walletName,
+      this.walletConfig.COMMON.EXTENSION_START_PATH,
+    );
     if (this.ethereumNodeService.state) {
       await this.ethereumNodeService.mockRoute(
         this.nodeUrl,
@@ -68,29 +74,42 @@ export class BrowserContextService {
     }
   }
 
-  async setExtensionVars(extensionStartPath: string) {
-    const manifest = await this.extensionService.getManifestVersion(
-      this.walletConfig.EXTENSION_PATH,
-    );
-    switch (manifest) {
-      case Manifest.v2: {
-        let [background] = this.browserContext.backgroundPages();
-        if (background === undefined)
-          background = await this.browserContext.waitForEvent('backgroundpage');
-        this.extensionPage = background;
-        this.extensionId = background.url().split('/')[2];
-        break;
-      }
-      case Manifest.v3: {
-        let [background] = this.browserContext.serviceWorkers();
-        if (!background)
-          background = await this.browserContext.waitForEvent('serviceworker');
-        const extensionId = background.url().split('/')[2];
-        this.extensionPage = await this.browserContext.newPage();
-        await this.extensionPage.goto(
-          `chrome-extension://${extensionId}${extensionStartPath}`,
-        );
-        this.extensionId = extensionId;
+  async setExtensionVars(walletName: string, extensionStartPath: string) {
+    if (walletName === 'bitKeep') {
+      const page = await this.browserContext.newPage();
+      await page.goto('chrome://extensions/');
+      await page.click('id=devMode');
+      let extensionId = await page.locator('id=extension-id').textContent();
+      extensionId = extensionId.replace('ID: ', '');
+      this.extensionId = extensionId;
+    } else {
+      const manifest = await this.extensionService.getManifestVersion(
+        this.walletConfig.EXTENSION_PATH,
+      );
+      switch (manifest) {
+        case Manifest.v2: {
+          let [background] = this.browserContext.backgroundPages();
+          if (background === undefined)
+            background = await this.browserContext.waitForEvent(
+              'backgroundpage',
+            );
+          this.extensionPage = background;
+          this.extensionId = background.url().split('/')[2];
+          break;
+        }
+        case Manifest.v3: {
+          let [background] = this.browserContext.serviceWorkers();
+          if (!background)
+            background = await this.browserContext.waitForEvent(
+              'serviceworker',
+            );
+          const extensionId = background.url().split('/')[2];
+          this.extensionPage = await this.browserContext.newPage();
+          await this.extensionPage.goto(
+            `chrome-extension://${extensionId}${extensionStartPath}`,
+          );
+          this.extensionId = extensionId;
+        }
       }
     }
   }

--- a/wallets-testing/browser/browser.context.service.ts
+++ b/wallets-testing/browser/browser.context.service.ts
@@ -3,10 +3,7 @@ import { BrowserContext, chromium, Page } from 'playwright';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import {
-  CommonWalletConfig,
-  WalletConfig,
-} from '@lidofinance/wallets-testing-wallets';
+import { WalletConfig } from '@lidofinance/wallets-testing-wallets';
 import { EthereumNodeService } from '@lidofinance/wallets-testing-nodes';
 import {
   ExtensionService,

--- a/wallets-testing/browser/browser.service.ts
+++ b/wallets-testing/browser/browser.service.ts
@@ -82,6 +82,7 @@ export class BrowserService {
         commonWalletConfig.STORE_EXTENSION_ID,
       );
     await this.browserContextService.setup(
+      commonWalletConfig.WALLET_NAME,
       walletConfig,
       this.widgetConfig.nodeUrl,
     );

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -12,6 +12,7 @@ import {
   EXODUS_COMMON_CONFIG,
   XDEFI_COMMON_CONFIG,
   OKX_COMMON_CONFIG,
+  BItKEEP_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import { ETHEREUM_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
@@ -90,6 +91,11 @@ test.describe('Ethereum', () => {
 
   test(`OKX connect`, async () => {
     await browserService.setup(OKX_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`BitKeep connect`, async () => {
+    await browserService.setup(BItKEEP_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 


### PR DESCRIPTION
- Added BitKeep wallet connect test to ETH
- Added logic to detect extensionId in browser.context.serivece.ts -> setExtensionVars() since the setExtensionVars() cannot recognize the manifest version since the bitKeep manifest has a persistence: false proprety which mean that extension doesn't leave in background until manual call.