### PR TITLE
Wallets fixes

### DIFF
--- a/packages/wallets/src/bitKeep/bitKeep.page.ts
+++ b/packages/wallets/src/bitKeep/bitKeep.page.ts
@@ -60,10 +60,11 @@ export class BitKeepPage implements WalletPage {
         this.config.PASSWORD,
       );
       await this.page.click("button:has-text('Next')");
-      await this.page.fill(
-        'textarea[id=outlined-multiline-static]',
-        this.config.SECRET_PHRASE,
-      );
+      const inputs = this.page.locator('.wordInput-contaniner-input');
+      const seedWords = this.config.SECRET_PHRASE.split(' ');
+      for (let i = 0; i < seedWords.length; i++) {
+        await inputs.nth(i).fill(seedWords[i]);
+      }
       await this.page.click("button:has-text('Confirm')");
       await this.page.waitForSelector('text=Wallet successfully imported');
     });

--- a/packages/wallets/src/coin98/coin98.page.ts
+++ b/packages/wallets/src/coin98/coin98.page.ts
@@ -26,8 +26,7 @@ export class Coin98 implements WalletPage {
     await test.step('Setup', async () => {
       await this.navigate();
       if (!this.page) throw "Page isn't ready";
-      const firstTime =
-        (await this.page.locator('text=Create Wallet').count()) > 0;
+      const firstTime = await this.page.waitForSelector('text=Restore Wallet');
       if (firstTime) await this.firstTimeSetup(network);
     });
   }
@@ -45,13 +44,14 @@ export class Coin98 implements WalletPage {
       await this.page.click('button:has-text("Ok")');
       await this.page.click('button:has-text("Confirm")');
       await this.page.fill('[placeholder="Search chain"]', network);
-      await this.page.click('.box-logo');
+      await this.page.getByText('Ethereum', { exact: true }).click();
       await this.page.fill('[placeholder="Wallet name"]', 'test');
       await this.page.fill(
-        '.content-editable--password',
+        'div[class="relative w-full"] >> div',
         this.config.SECRET_PHRASE,
       );
-      await this.page.click('button:has-text("Restore")');
+      await this.page.locator('button:has-text("Restore")').nth(1).click();
+      await this.page.waitForSelector('text=Success!');
     });
   }
 
@@ -71,7 +71,18 @@ export class Coin98 implements WalletPage {
 
   async connectWallet(page: Page) {
     await test.step('Connect wallet', async () => {
+      await this.unlock(page);
       await page.click('button:has-text("Connect")');
+    });
+  }
+
+  async unlock(page: Page) {
+    await test.step('Unlock', async () => {
+      await page.waitForSelector('input[name="password"]');
+      if ((await page.locator('input[name="password"]').count()) > 0) {
+        await page.fill('input[name=password]', this.config.PASSWORD);
+        await page.click('text=Unlock Wallet');
+      }
     });
   }
 

--- a/wallets-testing/browser/browser.service.ts
+++ b/wallets-testing/browser/browser.service.ts
@@ -92,6 +92,7 @@ export class BrowserService {
       extension.url,
       walletConfig,
     );
+    await this.browserContextService.closePages();
     await this.walletPage.setup(this.widgetConfig.networkName);
     if (!this.widgetConfig.isDefaultNetwork)
       await this.walletPage.addNetwork(


### PR DESCRIPTION
- updated coin98 wallet connection test
- updated bitKeep wallet connection test
- added closePage() in browserService.setup() to avoid double opened wallet setup tabs due to coin98 displayed "Multiple Windows are detected, close another window before continuing!" conflict if 2 extension tabs opened
![image](https://github.com/lidofinance/wallets-testing-modules/assets/19698566/415eb766-420c-43df-b7ac-8499379ee19b)
