### PR TITLE
Update for MM

### DIFF
--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -202,10 +202,10 @@ export class MetamaskPage implements WalletPage {
 
   async assertReceiptAddress(page: Page, expectedAddress: string) {
     await test.step('Assert receiptAddress/Contract', async () => {
-      await page.click('text=Liquid staked Ether 2.0');
+      await page.getByTestId('sender-to-recipient__name').click();
       const receiptAddress = await page
-        .locator(`text=${expectedAddress}`)
-        .innerText();
+        .locator('div[class="nickname-popover__public-address__constant"]')
+        .textContent();
       await page.click('button[data-testid=popover-close]');
       expect(receiptAddress).toBe(expectedAddress);
     });

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -176,8 +176,12 @@ export class MetamaskPage implements WalletPage {
     });
   }
 
-  async confirmTx(page: Page) {
+  async confirmTx(page: Page, setAggressiveGas?: boolean) {
     await test.step('Confirm TX', async () => {
+      if (setAggressiveGas) {
+        await page.getByTestId('edit-gas-fee-button').click();
+        await page.getByTestId('edit-gas-fee-item-high').click();
+      }
       await page.click('text=Confirm');
     });
   }

--- a/packages/wallets/src/wallet.page.ts
+++ b/packages/wallets/src/wallet.page.ts
@@ -13,7 +13,7 @@ export interface WalletPage {
 
   assertTxAmount(page: Page, expectedAmount: string): Promise<void>;
 
-  confirmTx(page: Page): Promise<void>;
+  confirmTx(page: Page, setAggressiveGas?: boolean): Promise<void>;
 
   approveTokenTx?(page: Page): Promise<void>;
 

--- a/packages/widgets/src/ethereum/ethereum.page.ts
+++ b/packages/widgets/src/ethereum/ethereum.page.ts
@@ -79,7 +79,7 @@ export class EthereumPage implements WidgetPage {
         walletSignPage,
         String(ETHEREUM_WIDGET_CONFIG.stakeContract),
       );
-      await walletPage.confirmTx(walletSignPage);
+      await walletPage.confirmTx(walletSignPage, true);
     });
   }
 }


### PR DESCRIPTION
- [feat: add aggerssive gas cost option for confirmTx()] - ability to set aggressive gas coast to speed up tx time and don' fail on waitTimeout for page
- [fix: make assertReceiptAddress() reusable for any network] - set more abstract locators for assertReceiptAddress() to use it in any network. For now was that was parsed constant for ETH stake contract in MM as 'text=Liquid staked Ether 2.0',but it`s not worked for example for Goerli network since it's not parsed as a Lido stake contract via MM