### PR TITLE
Wallets update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18.15'
+          node-version: 16
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --immutable

--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -76,7 +76,7 @@ export class OkxPage implements WalletPage {
             .locator(
               `div[class="mnemonic-words-inputs__container__candidate-word"]`,
             )
-            .getByText('bus', { exact: true })
+            .getByText(`${seedWords[i]}`, { exact: true })
             .click();
         }
       }

--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -65,7 +65,7 @@ export class OkxPage implements WalletPage {
       for (let i = 0; i < seedWords.length; i++) {
         await inputs.nth(i).fill(seedWords[i]);
         if (
-          i == seedWords.length - 1 &&
+          i === seedWords.length - 1 &&
           (await this.page
             .locator(
               'div[class="mnemonic-words-inputs__container__candidate columns-3"]',

--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -148,7 +148,7 @@ export class OkxPage implements WalletPage {
       await page.waitForSelector('button:has-text("Connect")');
       await page.waitForTimeout(10000);
       await page.getByRole('button', { name: 'Connect' }).click();
-      await page.waitForSelector('text=Connected');
+      // await page.waitForSelector('text=Connected');
       await page.close();
     });
   }

--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -64,6 +64,21 @@ export class OkxPage implements WalletPage {
       const seedWords = this.config.SECRET_PHRASE.split(' ');
       for (let i = 0; i < seedWords.length; i++) {
         await inputs.nth(i).fill(seedWords[i]);
+        if (
+          i == seedWords.length - 1 &&
+          (await this.page
+            .locator(
+              'div[class="mnemonic-words-inputs__container__candidate columns-3"]',
+            )
+            .count()) > 0
+        ) {
+          await this.page
+            .locator(
+              `div[class="mnemonic-words-inputs__container__candidate-word"]`,
+            )
+            .getByText('bus', { exact: true })
+            .click();
+        }
       }
       await this.page.getByRole('button', { name: 'Confirm' }).click();
       await this.page

--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -68,8 +68,9 @@ export class OkxPage implements WalletPage {
           i === seedWords.length - 1 &&
           (await this.page
             .locator(
-              'div[class="mnemonic-words-inputs__container__candidate columns-3"]',
+              `div[class="mnemonic-words-inputs__container__candidate-word"]`,
             )
+            .getByText(`${seedWords[i]}`)
             .count()) > 0
         ) {
           await this.page

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -13,6 +13,7 @@ import {
   XDEFI_COMMON_CONFIG,
   OKX_COMMON_CONFIG,
   BITGET_COMMON_CONFIG,
+  PHANTOM_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import { ETHEREUM_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
@@ -96,6 +97,11 @@ test.describe('Ethereum', () => {
 
   test(`Bitget connect`, async () => {
     await browserService.setup(BITGET_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Phantom connect`, async () => {
+    await browserService.setup(PHANTOM_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -62,7 +62,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test(`Exodus connect`, async () => {
+  test.skip(`Exodus connect`, async () => {
     await browserService.setup(EXODUS_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -61,7 +61,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test.only(`Exodus connect`, async () => {
+  test(`Exodus connect`, async () => {
     await browserService.setup(EXODUS_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
@@ -84,7 +84,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test.skip(`Xdefi wallet connect`, async () => {
+  test(`Xdefi wallet connect`, async () => {
     await browserService.setup(XDEFI_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -61,7 +61,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test.skip(`Exodus connect`, async () => {
+  test.only(`Exodus connect`, async () => {
     await browserService.setup(EXODUS_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -94,7 +94,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test(`bitget connect`, async () => {
+  test(`Bitget connect`, async () => {
     await browserService.setup(BITGET_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -89,7 +89,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test.skip(`OKX connect`, async () => {
+  test(`OKX connect`, async () => {
     await browserService.setup(OKX_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -10,6 +10,7 @@ import {
   OKX_COMMON_CONFIG,
   BITGET_COMMON_CONFIG,
   TAHO_COMMON_CONFIG,
+  TRUST_WALLET_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import {
   ETHEREUM_WIDGET_CONFIG,
@@ -78,6 +79,14 @@ test.describe('Polygon', () => {
 
   test(`Taho connect`, async () => {
     await browserService.setup(TAHO_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Trust wallet connect`, async () => {
+    await browserService.setup(
+      TRUST_WALLET_COMMON_CONFIG,
+      POLYGON_WIDGET_CONFIG,
+    );
     await browserService.connectWallet();
   });
 

--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -11,6 +11,7 @@ import {
   BITGET_COMMON_CONFIG,
   TAHO_COMMON_CONFIG,
   TRUST_WALLET_COMMON_CONFIG,
+  PHANTOM_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import {
   ETHEREUM_WIDGET_CONFIG,
@@ -87,6 +88,11 @@ test.describe('Polygon', () => {
       TRUST_WALLET_COMMON_CONFIG,
       POLYGON_WIDGET_CONFIG,
     );
+    await browserService.connectWallet();
+  });
+
+  test(`Phantom connect`, async () => {
+    await browserService.setup(PHANTOM_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 

--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -13,10 +13,7 @@ import {
   TRUST_WALLET_COMMON_CONFIG,
   PHANTOM_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
-import {
-  ETHEREUM_WIDGET_CONFIG,
-  POLYGON_WIDGET_CONFIG,
-} from '@lidofinance/wallets-testing-widgets';
+import { POLYGON_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
 import { BrowserService } from '../../browser/browser.service';
 import { MATIC_TOKEN } from './consts';

--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -9,8 +9,12 @@ import {
   EXODUS_COMMON_CONFIG,
   OKX_COMMON_CONFIG,
   BITGET_COMMON_CONFIG,
+  TAHO_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
-import { POLYGON_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
+import {
+  ETHEREUM_WIDGET_CONFIG,
+  POLYGON_WIDGET_CONFIG,
+} from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
 import { BrowserService } from '../../browser/browser.service';
 import { MATIC_TOKEN } from './consts';
@@ -69,6 +73,11 @@ test.describe('Polygon', () => {
 
   test(`BitGet connect`, async () => {
     await browserService.setup(BITGET_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Taho connect`, async () => {
+    await browserService.setup(TAHO_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 

--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -8,6 +8,7 @@ import {
   COINBASE_COMMON_CONFIG,
   EXODUS_COMMON_CONFIG,
   OKX_COMMON_CONFIG,
+  BITGET_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import { POLYGON_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
@@ -63,6 +64,11 @@ test.describe('Polygon', () => {
 
   test.skip(`OKX connect`, async () => {
     await browserService.setup(OKX_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`BitGet connect`, async () => {
+    await browserService.setup(BITGET_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 


### PR DESCRIPTION
- fix OKX test since at the last seed word input there is was multi-select of wording 
![image](https://github.com/lidofinance/wallets-testing-modules/assets/19698566/bf75de44-b47f-41cd-bc3f-58ae9bef869b)

- add bitGet,taho,trust wallest connect to polygon
- enable xdefi since looks like it's fixed indirectly
- add phantom connect to ETH&polygon widgets

