### PR TITLE
Wallets update

### DIFF
--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -64,6 +64,22 @@ export class OkxPage implements WalletPage {
       const seedWords = this.config.SECRET_PHRASE.split(' ');
       for (let i = 0; i < seedWords.length; i++) {
         await inputs.nth(i).fill(seedWords[i]);
+        if (
+          i === seedWords.length - 1 &&
+          (await this.page
+            .locator(
+              `div[class="mnemonic-words-inputs__container__candidate-word"]`,
+            )
+            .getByText(`${seedWords[i]}`)
+            .count()) > 0
+        ) {
+          await this.page
+            .locator(
+              `div[class="mnemonic-words-inputs__container__candidate-word"]`,
+            )
+            .getByText(`${seedWords[i]}`, { exact: true })
+            .click();
+        }
       }
       await this.page.getByRole('button', { name: 'Confirm' }).click();
       await this.page
@@ -132,7 +148,6 @@ export class OkxPage implements WalletPage {
       await page.waitForSelector('button:has-text("Connect")');
       await page.waitForTimeout(10000);
       await page.getByRole('button', { name: 'Connect' }).click();
-      await page.waitForSelector('text=Connected');
       await page.close();
     });
   }

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -84,7 +84,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test.skip(`Xdefi wallet connect`, async () => {
+  test(`Xdefi wallet connect`, async () => {
     await browserService.setup(XDEFI_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -13,6 +13,7 @@ import {
   XDEFI_COMMON_CONFIG,
   OKX_COMMON_CONFIG,
   BITGET_COMMON_CONFIG,
+  PHANTOM_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import { ETHEREUM_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
@@ -94,8 +95,13 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test(`bitget connect`, async () => {
+  test(`Bitget connect`, async () => {
     await browserService.setup(BITGET_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Phantom connect`, async () => {
+    await browserService.setup(PHANTOM_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 

--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -89,7 +89,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test.skip(`OKX connect`, async () => {
+  test(`OKX connect`, async () => {
     await browserService.setup(OKX_COMMON_CONFIG, ETHEREUM_WIDGET_CONFIG);
     await browserService.connectWallet();
   });

--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -8,6 +8,10 @@ import {
   COINBASE_COMMON_CONFIG,
   EXODUS_COMMON_CONFIG,
   OKX_COMMON_CONFIG,
+  BITGET_COMMON_CONFIG,
+  TAHO_COMMON_CONFIG,
+  TRUST_WALLET_COMMON_CONFIG,
+  PHANTOM_COMMON_CONFIG,
 } from '@lidofinance/wallets-testing-wallets';
 import { POLYGON_WIDGET_CONFIG } from '@lidofinance/wallets-testing-widgets';
 import { BrowserModule } from '../../browser/browser.module';
@@ -63,6 +67,29 @@ test.describe('Polygon', () => {
 
   test.skip(`OKX connect`, async () => {
     await browserService.setup(OKX_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`BitGet connect`, async () => {
+    await browserService.setup(BITGET_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Taho connect`, async () => {
+    await browserService.setup(TAHO_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
+    await browserService.connectWallet();
+  });
+
+  test(`Trust wallet connect`, async () => {
+    await browserService.setup(
+      TRUST_WALLET_COMMON_CONFIG,
+      POLYGON_WIDGET_CONFIG,
+    );
+    await browserService.connectWallet();
+  });
+
+  test(`Phantom connect`, async () => {
+    await browserService.setup(PHANTOM_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
     await browserService.connectWallet();
   });
 


### PR DESCRIPTION
- fix OKX test since at the last seed word input there is was multi-select of wording 
![image](https://github.com/lidofinance/wallets-testing-modules/assets/19698566/bf75de44-b47f-41cd-bc3f-58ae9bef869b)

- add bitGet,taho,trust, phantom wallets connect tests to polygon
- enable xdefi since looks like it's fixed indirectly
- add phantom connect to ETH

