### PR TITLE
fix MM getTokenBalance()

### DIFF
--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -224,10 +224,21 @@ export class MetamaskPage implements WalletPage {
 
   async getTokenBalance(tokenName: string) {
     await this.navigate();
-    await this.page
-      .getByTestId('multichain-token-list-button')
-      .locator(`p:has-text(${tokenName})`)
-      .textContent();
+    //Cannot find locator by exact text since need to find row by text "stETH"/"ETH" but "stETH" contains "ETH"
+    const elements = await this.page.$$(
+      'data-testid=multichain-token-list-item-value',
+    );
+    let tokenBalance = NaN;
+    for (const element of elements) {
+      await element.waitForElementState('visible');
+      const textContent = await element.textContent();
+      const letterTextContent = textContent.match(/[a-zA-Z]+/g);
+      if (letterTextContent.toString().trim() === tokenName) {
+        tokenBalance = parseFloat(await element.textContent());
+        break;
+      }
+    }
+    return tokenBalance;
   }
 
   async confirmTx(page: Page, setAggressiveGas?: boolean) {

--- a/packages/wallets/src/wallet.page.ts
+++ b/packages/wallets/src/wallet.page.ts
@@ -19,7 +19,7 @@ export interface WalletPage {
 
   openLastTxInEthplorer?(txIndex?: number): Promise<Page>;
 
-  getTokenBalance?(tokenName: string): Promise<void>;
+  getTokenBalance?(tokenName: string): Promise<number>;
 
   confirmAddTokenToWallet?(page: Page): Promise<void>;
 


### PR DESCRIPTION
fix token balance by token name since need to find by name 'stETH'/'ETH' but in row it's looks like '0.1233 ETH' && '10 stETH'. If find by page.getByTestId('multichain-token-list-item-value').getByText('stETH'/'ETH') the inpu of  'ETH' will always resolve 2 elements since 'ETH' contain 'st[ETH]'. Option {exact:true} not worked because there is string value of token - "[10] stETH"