### PR TITLE
fix: try force click on MM onboarding-terms-checkbox

### DIFF
--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -71,7 +71,9 @@ export class MetamaskPage implements WalletPage {
   async firstTimeSetup() {
     await test.step('First time setup', async () => {
       if (!this.page) throw "Page isn't ready";
-      await this.page.click('data-testid=onboarding-terms-checkbox');
+      await this.page.click('data-testid=onboarding-terms-checkbox', {
+        force: true,
+      });
       await this.page.click('data-testid=onboarding-import-wallet');
       await this.page.click('data-testid=metametrics-i-agree');
       const inputs = this.page.locator(


### PR DESCRIPTION
- try to avoid "attempting click action  waiting for element to be visible, enabled and stable" by ```
{
        force: true,
      });
```
```
waiting for locator('data-testid=onboarding-terms-checkbox')
  locator resolved to <input readonly type="checkbox" id="onboarding__terms-c…/>
attempting click action  waiting for element to be visible, enabled and stable
```

![image](https://github.com/lidofinance/wallets-testing-modules/assets/19698566/0bf0cf52-a719-43c7-8d72-3c792ca686e5)
Some times it's happens with checkbox locators
