### PR TITLE
chore: reuse extension during run

### DIFF
--- a/packages/extensions/src/extension.service.ts
+++ b/packages/extensions/src/extension.service.ts
@@ -37,17 +37,15 @@ export class ExtensionService {
     const extensionDirById = `${this.extensionDirBasePath}/${id}`;
     try {
       await fs.mkdir(extensionDirById);
-      this.logger.debug(`Dir for the extension created ${extensionDirById}`);
       return extensionDirById;
     } catch (error) {
-      this.logger.debug('', error);
+      this.logger.debug('Extension dir by id not created', error);
       return extensionDirById;
     }
   }
   async createBaseExtensionDir() {
     try {
       await fs.access(`${this.extensionDirBasePath}`, fs.constants.F_OK);
-      this.logger.debug(`Extension base dir exist`);
     } catch (error) {
       await fs.mkdir(`${this.extensionDirBasePath}`);
       this.logger.debug(error);
@@ -59,7 +57,6 @@ export class ExtensionService {
       const files = await fs.readdir(`${this.extensionDirBasePath}/${id}`);
       return files.length < 0;
     } catch (error) {
-      this.logger.debug('Extension dir not exist/Unexpected error', error);
       return true;
     }
   }

--- a/packages/extensions/src/extension.service.ts
+++ b/packages/extensions/src/extension.service.ts
@@ -39,14 +39,14 @@ export class ExtensionService {
       await fs.access(extensionDirById, fs.constants.F_OK);
       return (this.urlToExtension[id] = extensionDirById);
     } catch (error) {
-      await fs.mkdir(this.extensionDirBasePath);
+      await fs.mkdir(extensionDirById);
       this.logger.debug(`Dir for the extension created`);
       return extensionDirById;
     }
   }
-  async isExtensionDirEmpty() {
+  async isExtensionDirEmpty(id: string) {
     try {
-      const files = await fs.readdir(this.extensionDirBasePath);
+      const files = await fs.readdir(`${this.extensionDirBasePath}/${id}`);
       return files.length < 0;
     } catch (error) {
       this.logger.debug('Extension dir not exist/Unexpected error', error);
@@ -69,7 +69,7 @@ export class ExtensionService {
   }
 
   async downloadFromStore(id: string) {
-    if (await this.isExtensionDirEmpty()) {
+    if (await this.isExtensionDirEmpty(id)) {
       this.logger.debug(`Download extension ${id} from chrome store`);
       const extensionDir = await this.createExtensionDir(id);
       const browser = await chromium.launch();


### PR DESCRIPTION
- reuse downloaded extension to prevent multiply downloads. Extension stores in extensions/extension directory in modules with temp directory.

Problems:
- Once extension is downloaded there is a check for isExtensionDirEmpty() which leads to outdated extension on distance for local development.
- Otherwise for e2e tests it's works since for each run there is only 1 download.