### PR TITLE
fix: skip Trust for Eth widget

### DIFF
--- a/wallets-testing/test/widgets/ethereum.spec.ts
+++ b/wallets-testing/test/widgets/ethereum.spec.ts
@@ -50,7 +50,7 @@ test.describe('Ethereum', () => {
     await browserService.connectWallet();
   });
 
-  test(`Trust connect`, async () => {
+  test.skip(`Trust connect`, async () => {
     await browserService.setup(
       TRUST_WALLET_COMMON_CONFIG,
       ETHEREUM_WIDGET_CONFIG,


### PR DESCRIPTION
Skip Trust wallet on eth widget while it's not resolved from Trust wallet side