### PR TITLE
fix: okx firstTimeSetup()

### DIFF
--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -59,7 +59,7 @@ export class OkxPage implements WalletPage {
     await test.step('First time setup', async () => {
       if (!this.page) throw "Page isn't ready";
       await this.page.click("button:has-text('Import wallet')");
-      await this.page.getByText('Import wallet').click();
+      await this.page.getByText('Import wallet').last().click();
       await this.page.click('text=Seed Phrase');
       const inputs = this.page.locator('div[data-testid="okd-popup"] >> input');
       const seedWords = this.config.SECRET_PHRASE.split(' ');


### PR DESCRIPTION
- Fix okx firstTimeSetup. Okx added one more label with "Import wallet" as the tittle and there is was conflicts with 2 texts. Locators isn't so good since there is only divs without good locators
![image](https://github.com/lidofinance/wallets-testing-modules/assets/19698566/f1d6e329-3dc8-4eda-9f56-221220f4ba51)
