### PR TITLE
reject tx 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "rejectTx",
+        "name": "develop",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "develop",
+        "name": "rejectTx",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -114,13 +114,22 @@ export class MetamaskPage implements WalletPage {
       if (await this.page.getByText('Not right now').isVisible())
         await this.page.click('text=Not right now');
 
-      const gotItBtn = await this.page.getByText('Got it');
+      const gotItBtn = this.page.getByText('Got it');
       if (await gotItBtn.first().isVisible()) await gotItBtn.first().click();
 
-      const rejectTxBtn = this.page.getByTestId('page-container-footer-cancel');
-      while (await rejectTxBtn.isVisible({ timeout: 1000 }))
-        await this.rejectTx(this.page);
+      // reject tx in queue.
+      while (await this.isTxInQueue()) await this.rejectTx(this.page);
     });
+  }
+
+  async isTxInQueue() {
+    try {
+      const rejectTxBtn = this.page.getByTestId('page-container-footer-cancel');
+      await rejectTxBtn.waitFor({ state: 'visible', timeout: 1000 });
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 
   async firstTimeSetup() {

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -116,6 +116,10 @@ export class MetamaskPage implements WalletPage {
 
       const gotItBtn = await this.page.getByText('Got it');
       if (await gotItBtn.first().isVisible()) await gotItBtn.first().click();
+
+      const rejectTxBtn = this.page.getByTestId('page-container-footer-cancel');
+      while (await rejectTxBtn.isVisible({ timeout: 1000 }))
+        await this.rejectTx(this.page);
     });
   }
 
@@ -342,7 +346,7 @@ export class MetamaskPage implements WalletPage {
 
   async rejectTx(page: Page) {
     await test.step('Reject TX', async () => {
-      await page.click('text=Reject');
+      await page.getByTestId('page-container-footer-cancel').click();
     });
   }
 

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -131,23 +131,13 @@ export class MetamaskPage implements WalletPage {
       //No tx in queue
       return;
     }
-    //rejectTxBtn visible - there is any tx in queue
-    const txQueueText = this.page.locator(
-      "xpath=//div[text()='requests waiting to be acknowledged']/preceding-sibling::div",
-    );
-    // if "requests waiting to be acknowledge" displayed that's mean there is >1 tx in queue
-    if (await txQueueText.isVisible()) {
-      const locatorText = await this.page
-        .locator(
-          "xpath=//div[text()='requests waiting to be acknowledged']/preceding-sibling::div",
-        )
-        .textContent();
-      let txQueueCount = parseFloat(locatorText.replace('1 of', '').trim());
 
-      for (; txQueueCount > 0; txQueueCount--) {
-        await this.rejectTx(this.page);
-      }
-      // "requests waiting to be acknowledge" not displayed - reject only 1 time
+    const rejectTxsBtn = this.page.locator(
+      'div[class="page-container__footer-secondary"]',
+    );
+    if (await rejectTxsBtn.isVisible()) {
+      await rejectTxsBtn.click();
+      await this.page.locator('button:has-text("Reject all")').click();
     } else await this.rejectTx(this.page);
   }
 

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -378,11 +378,6 @@ export class MetamaskPage implements WalletPage {
       await page.getByTestId('page-container-footer-cancel').click();
     });
   }
-  async rejectTx1(page: Page) {
-    await test.step('Reject TX1', async () => {
-      await page.getByTestId('page-container-footer-cancel').click();
-    });
-  }
 
   async approveTokenTx(page: Page) {
     await test.step('Approve token tx', async () => {


### PR DESCRIPTION
Since shared browser_context saves data about ongoing but not confirmed transaction and passes it to new opened contex there is `jectAllTxInQueue()` in navigation() MM. It should reject all tx's while.
rejectAllTxInQueue- add `rejectAllTxInQueue()` into navigation() function to reject queue TX from prev tx context fails