### PR TITLE
Update fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "update-fixes",
+        "name": "develop",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "refactor-mm-page-objects",
+        "name": "update-fixes",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/packages/wallets/src/metamask/pages/home.page.ts
+++ b/packages/wallets/src/metamask/pages/home.page.ts
@@ -80,6 +80,7 @@ export class HomePage {
         this.page.context().waitForEvent('page', { timeout: 10000 }),
         this.transactionExplorerButton.click(),
       ]);
+      await this.page.close();
       return etherscanPage;
     });
   }


### PR DESCRIPTION
- close wallet page after ethplorer to avoid conflicts like this https://app.qase.io/run/LOE/dashboard/821/ee8ab7334c7b4a39e361ca5a475b8f0a0c3d6511/371b75755fe6499f570ea94974980dbec6d6a9d2 . Not sure, but looks like since there for fixture scope worker for openLastTxInEthplorer() functino that used only in stake test by order queue usually unwrap test fails since it's awaiting confirmation pop-up but it's not displayed. In fail screenshot there is wallet page with opene activity tab