### PR TITLE
fix: skip coin98 for polygon widget

### DIFF
--- a/wallets-testing/test/widgets/polygon.spec.ts
+++ b/wallets-testing/test/widgets/polygon.spec.ts
@@ -42,7 +42,8 @@ test.describe('Polygon', () => {
     await browserService.stake();
   });
 
-  test(`Coin98 connect`, async () => {
+  //skipped since of broken connection to polygon widget
+  test.skip(`Coin98 connect`, async () => {
     await browserService.setup(COIN98_COMMON_CONFIG, POLYGON_WIDGET_CONFIG);
     await browserService.connectWallet();
   });


### PR DESCRIPTION
- skip coin98 connection for polygon widget since there is issues with connection on polygon widget side