### PR TITLE
fix: mm connect flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "develop",
+        "name": "update-mm",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prettier": "^2.8.1",
     "release-it": "^15.6.0",
     "tslib": "^2.4.1",
-    "typescript": "4.7.4"
+    "typescript": "5.1.6"
   },
   "lint-staged": {
     "./**/src/**/*.ts": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "update-mm",
+        "name": "develop",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -32,6 +32,7 @@
     "@playwright/test": "^1.44.1",
     "expect": "^28.1.3",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.5.6"
+    "rxjs": "^7.5.6",
+    "viem": "^2.21.40"
   }
 }

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -156,8 +156,7 @@ export class MetamaskPage implements WalletPage {
   async connectWallet(page: Page) {
     await test.step('Connect Metamask wallet', async () => {
       const operationPage = new WalletOperationPage(page);
-      await operationPage.nextButton.click(); // "Next" button for account select
-      await operationPage.nextButton.click(); // "Confirm" button to give permission
+      await operationPage.connectBtn.click(); // "Confirm" button to give permission
       await operationPage.page.close();
     });
   }

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -240,11 +240,8 @@ export class MetamaskPage implements WalletPage {
       await this.navigate();
       await this.header.optionsMenuButton.click();
       await this.optionsMenu.menuAccountDetailsButton.click();
-      const address = await this.page
-        .locator(
-          '//div[@data-testid="address-copy-button-text"]/preceding-sibling::p',
-        )
-        .textContent();
+      const address =
+        await this.popoverElements.accountDetailAddressLabel.textContent();
       await this.page.close();
       return getAddress(address);
     });

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -12,6 +12,7 @@ import {
   PopoverElements,
   AccountMenu,
 } from './pages/elements';
+import { getAddress } from 'viem';
 
 export class MetamaskPage implements WalletPage {
   page: Page | undefined;
@@ -239,10 +240,13 @@ export class MetamaskPage implements WalletPage {
       await this.navigate();
       await this.header.optionsMenuButton.click();
       await this.optionsMenu.menuAccountDetailsButton.click();
-      const address =
-        await this.popoverElements.accountDetailCopyAddressButton.textContent();
+      const address = await this.page
+        .locator(
+          '//div[@data-testid="address-copy-button-text"]/preceding-sibling::p',
+        )
+        .textContent();
       await this.page.close();
-      return address;
+      return getAddress(address);
     });
   }
 

--- a/packages/wallets/src/metamask/pages/elements/popover.element.ts
+++ b/packages/wallets/src/metamask/pages/elements/popover.element.ts
@@ -8,7 +8,7 @@ export class PopoverElements {
   gotItButton: Locator;
   noThanksButton: Locator;
   switchToButton: Locator;
-  accountDetailCopyAddressButton: Locator;
+  accountDetailAddressLabel: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -20,8 +20,8 @@ export class PopoverElements {
     this.noThanksButton = this.page.getByText('No thanks');
     this.gotItButton = this.page.getByText('Got it');
     this.switchToButton = this.page.getByText('Switch to ');
-    this.accountDetailCopyAddressButton = this.page.getByTestId(
-      'address-copy-button-text',
+    this.accountDetailAddressLabel = this.page.locator(
+      '//div[@data-testid="address-copy-button-text"]/preceding-sibling::p',
     );
   }
 

--- a/packages/wallets/src/metamask/pages/walletOperations.page.ts
+++ b/packages/wallets/src/metamask/pages/walletOperations.page.ts
@@ -3,6 +3,7 @@ import { Locator, Page, test } from '@playwright/test';
 export class WalletOperationPage {
   page: Page;
   nextButton: Locator;
+  connectBtn: Locator;
   confirmButton: Locator;
   approvalCancelButton: Locator;
   cancelButton: Locator;
@@ -21,6 +22,7 @@ export class WalletOperationPage {
   constructor(page: Page) {
     this.page = page;
     this.nextButton = this.page.getByTestId('page-container-footer-next');
+    this.connectBtn = this.page.getByTestId('confirm-btn');
     this.confirmButton = this.page.getByTestId('confirm-footer-button');
     this.approvalCancelButton = this.page.getByTestId(
       'page-container-footer-cancel',

--- a/packages/wallets/src/metamask/pages/walletOperations.page.ts
+++ b/packages/wallets/src/metamask/pages/walletOperations.page.ts
@@ -21,7 +21,7 @@ export class WalletOperationPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.nextButton = this.page.getByTestId('page-container-footer-next');
+    this.nextButton = this.page.getByTestId('confirm-footer-button');
     this.connectBtn = this.page.getByTestId('confirm-btn');
     this.confirmButton = this.page.getByTestId('confirm-footer-button');
     this.approvalCancelButton = this.page.getByTestId(

--- a/packages/wallets/src/metamask/pages/walletOperations.page.ts
+++ b/packages/wallets/src/metamask/pages/walletOperations.page.ts
@@ -2,7 +2,6 @@ import { Locator, Page, test } from '@playwright/test';
 
 export class WalletOperationPage {
   page: Page;
-  nextButton: Locator;
   connectBtn: Locator;
   confirmButton: Locator;
   approvalCancelButton: Locator;
@@ -21,7 +20,6 @@ export class WalletOperationPage {
 
   constructor(page: Page) {
     this.page = page;
-    this.nextButton = this.page.getByTestId('confirm-footer-button');
     this.connectBtn = this.page.getByTestId('confirm-btn');
     this.confirmButton = this.page.getByTestId('confirm-footer-button');
     this.approvalCancelButton = this.page.getByTestId(
@@ -83,9 +81,9 @@ export class WalletOperationPage {
       if (await this.page.locator('text=Use default').isVisible())
         await this.page.click('text=Use default');
     });
-    await this.nextButton.click(); // click to the Next button
+    await this.confirmButton.click(); // click to the Next button
     await this.page.waitForTimeout(2000);
-    await this.nextButton.click(); // click to the Approve button
+    await this.confirmButton.click(); // click to the Approve button
   }
 
   async confirmTransaction(setAggressiveGas?: boolean) {

--- a/packages/wallets/src/metamask/pages/walletOperations.page.ts
+++ b/packages/wallets/src/metamask/pages/walletOperations.page.ts
@@ -81,9 +81,7 @@ export class WalletOperationPage {
       if (await this.page.locator('text=Use default').isVisible())
         await this.page.click('text=Use default');
     });
-    await this.confirmButton.click(); // click to the Next button
-    await this.page.waitForTimeout(2000);
-    await this.confirmButton.click(); // click to the Approve button
+    await this.confirmButton.click();
   }
 
   async confirmTransaction(setAggressiveGas?: boolean) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@adraffy/ens-normalize@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
+  integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -1204,6 +1209,18 @@
   dependencies:
     tslib "2.5.3"
 
+"@noble/curves@1.6.0", "@noble/curves@^1.4.0", "@noble/curves@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.6.0.tgz#be5296ebcd5a1730fccea4786d420f87abfeb40b"
+  integrity sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==
+  dependencies:
+    "@noble/hashes" "1.5.0"
+
+"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0", "@noble/hashes@~1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
+  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1643,6 +1660,28 @@
     semver "^7.5.1"
     signale "^1.4.0"
     stream-buffers "^3.0.2"
+
+"@scure/base@~1.1.7", "@scure/base@~1.1.8":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/bip32@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.5.0.tgz#dd4a2e1b8a9da60e012e776d954c4186db6328e6"
+  integrity sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==
+  dependencies:
+    "@noble/curves" "~1.6.0"
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.7"
+
+"@scure/bip39@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.4.0.tgz#664d4f851564e2e1d4bffa0339f9546ea55960a6"
+  integrity sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==
+  dependencies:
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.8"
 
 "@semantic-release/commit-analyzer@^9.0.2":
   version "9.0.2"
@@ -2338,6 +2377,11 @@ abbrev@^1.0.0, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abitype@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.6.tgz#76410903e1d88e34f1362746e2d407513c38565b"
+  integrity sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==
 
 abstract-leveldown@^7.2.0:
   version "7.2.0"
@@ -5927,6 +5971,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isows@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.6.tgz#0da29d706fa51551c663c627ace42769850f86e7"
+  integrity sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==
+
 issue-parser@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/issue-parser/-/issue-parser-6.0.0.tgz#b1edd06315d4f2044a9755daf85fdafde9b4014a"
@@ -9300,16 +9349,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9364,14 +9404,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9857,15 +9890,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
 typescript@4.9.5, typescript@^4.3.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 uglify-js@^3.1.4:
   version "3.17.4"
@@ -10078,6 +10111,21 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+viem@^2.21.40:
+  version "2.21.40"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.40.tgz#d73a515e3eaf2a7ec2394d1de3d8409bf4bd2e21"
+  integrity sha512-no/mE3l7B0mdUTtvO7z/cTLENttQ/M7+ombqFGXJqsQrxv9wrYsTIGpS3za+FA5a447hY+x9D8Wxny84q1zAaA==
+  dependencies:
+    "@adraffy/ens-normalize" "1.11.0"
+    "@noble/curves" "1.6.0"
+    "@noble/hashes" "1.5.0"
+    "@scure/bip32" "1.5.0"
+    "@scure/bip39" "1.4.0"
+    abitype "1.0.6"
+    isows "1.0.6"
+    webauthn-p256 "0.0.10"
+    ws "8.18.0"
+
 vm2@^3.9.8:
   version "3.9.19"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.19.tgz#be1e1d7a106122c6c492b4d51c2e8b93d3ed6a4a"
@@ -10117,6 +10165,14 @@ web-streams-polyfill@^3.0.3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+
+webauthn-p256@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/webauthn-p256/-/webauthn-p256-0.0.10.tgz#877e75abe8348d3e14485932968edf3325fd2fdd"
+  integrity sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==
+  dependencies:
+    "@noble/curves" "^1.4.0"
+    "@noble/hashes" "^1.4.0"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -10274,7 +10330,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10287,15 +10343,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -10337,6 +10384,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
- updated mm `connectWallet()` flow 
- updated locator/flow  for `confirmTransactionOfTokenApproval()`
- added viem for `wallets` package to get  `getCheckSum` address 0x107209ce35ab1a0b3a22593ba85382817f471cd -> 0x107209CE35Ab1a0B3a22593ba85382817F471CDe since MM shows only in lower case. Bumped ts version to resolve conflicts with viem.
   - MM provide checkSummed address but only with "Copy to clipboard" button but for wallets setup there is no option to  get from clippoard since [metamask/lavamoat](https://github.com/LavaMoat/LavaMoat/pull/360) blocked it.
