### PR TITLE
Check the network toggle state

### DIFF
--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -69,8 +69,8 @@ export class MetamaskPage implements WalletPage {
         await this.onboardingPage.firstTimeSetup();
         await this.popoverElements.closePopover();
         await this.walletOperation.cancelAllTxInQueue(); // reject all tx in queue if exist
-        await this.settingsPage.setupNetworkChangingSetting(); // need to make it possible to change the wallet network
       }
+      await this.settingsPage.setupNetworkChangingSetting(); // need to make it possible to change the wallet network
     });
   }
 

--- a/packages/wallets/src/metamask/pages/settings.page.ts
+++ b/packages/wallets/src/metamask/pages/settings.page.ts
@@ -6,7 +6,7 @@ export class SettingsPage {
   tabBarMenu: Locator;
   experimentalTabButton: Locator;
 
-  inputNetworksForEachSiteToggleInput: Locator;
+  inputNetworksForEachSiteToggle: Locator;
   selectNetworksForEachSiteToggle: Locator;
 
   constructor(
@@ -21,11 +21,11 @@ export class SettingsPage {
       .getByText('Experimental');
 
     // Experimental page locators
-    this.inputNetworksForEachSiteToggleInput = this.page
+    this.inputNetworksForEachSiteToggle = this.page
       .getByTestId('experimental-setting-toggle-request-queue')
       .locator('input');
     this.selectNetworksForEachSiteToggle =
-      this.inputNetworksForEachSiteToggleInput.locator('..');
+      this.inputNetworksForEachSiteToggle.locator('..');
   }
 
   async openSettings() {
@@ -43,7 +43,7 @@ export class SettingsPage {
       await this.openSettings();
       await this.experimentalTabButton.click();
       const toggleState =
-        await this.inputNetworksForEachSiteToggleInput.getAttribute('value');
+        await this.inputNetworksForEachSiteToggle.getAttribute('value');
 
       if (toggleState === 'true') {
         await test.step('Turn off the toggle of the setting network changing', async () => {

--- a/packages/wallets/src/metamask/pages/settings.page.ts
+++ b/packages/wallets/src/metamask/pages/settings.page.ts
@@ -6,7 +6,7 @@ export class SettingsPage {
   tabBarMenu: Locator;
   experimentalTabButton: Locator;
 
-  selectNetworksForEachSiteToggleState: Locator;
+  inputNetworksForEachSiteToggleInput: Locator;
   selectNetworksForEachSiteToggle: Locator;
 
   constructor(
@@ -21,13 +21,11 @@ export class SettingsPage {
       .getByText('Experimental');
 
     // Experimental page locators
-    this.selectNetworksForEachSiteToggleState = this.page
+    this.inputNetworksForEachSiteToggleInput = this.page
       .getByTestId('experimental-setting-toggle-request-queue')
-      .locator('label');
-    this.selectNetworksForEachSiteToggle = this.page
-      .getByTestId('experimental-setting-toggle-request-queue')
-      .locator('input')
-      .locator('..');
+      .locator('input');
+    this.selectNetworksForEachSiteToggle =
+      this.inputNetworksForEachSiteToggleInput.locator('..');
   }
 
   async openSettings() {
@@ -41,10 +39,17 @@ export class SettingsPage {
   }
 
   async setupNetworkChangingSetting() {
-    await test.step('Turn off the toggle of the setting network changing', async () => {
+    await test.step('Check toggle state', async () => {
       await this.openSettings();
       await this.experimentalTabButton.click();
-      await this.selectNetworksForEachSiteToggle.click();
+      const toggleState =
+        await this.inputNetworksForEachSiteToggleInput.getAttribute('value');
+
+      if (toggleState === 'true') {
+        await test.step('Turn off the toggle of the setting network changing', async () => {
+          await this.selectNetworksForEachSiteToggle.click();
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
## Notes:
- Check the network toggle state every setup, because if the test run fails before toggle state is changed, the next test runs without that setting