### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @lidofinance/lido-qa
+.github @lidofinance/review-gh-workflows


### PR DESCRIPTION
- add `CODEOWNERS` for repo as 'lido-qa'
- add `CODEOWNERS` for gh-workflows as 'review-gh-workflows'