### PR TITLE
feat: add new method cancelAllTxInQueue

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
       "main",
       {
         "name": "feat/add_cancel_tx",
-        "channel": "alpha",
-        "prerelease": "alpha"
+        "channel": "alpha-mock",
+        "prerelease": "alpha-mock"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "branches": [
       "main",
       {
-        "name": "develop",
+        "name": "feat/add_cancel_tx",
         "channel": "alpha",
         "prerelease": "alpha"
       }

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "branches": [
       "main",
       {
-        "name": "feat/add_cancel_tx",
-        "channel": "alpha-mock",
-        "prerelease": "alpha-mock"
+        "name": "develop",
+        "channel": "alpha",
+        "prerelease": "alpha"
       }
     ]
   }

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -71,6 +71,7 @@ export class MetamaskPage implements WalletPage {
           }),
         ]);
       });
+      await this.initLocators();
       await this.homePage.openWidgetPage();
       await this.header.appHeaderLogo.waitFor({ state: 'visible' });
       await this.walletOperation.cancelAllTxInQueue(); // reject all tx in queue if exist

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -51,7 +51,7 @@ export class MetamaskPage implements WalletPage {
   async navigate() {
     await test.step('Navigate to metamask Home page', async () => {
       await this.initLocators();
-      await this.homePage.openWidgetPage();
+      await this.homePage.openExtensionPage();
       await this.header.appHeaderLogo.waitFor({ state: 'visible' });
       await this.loginPage.unlock();
       if (await this.header.networkListButton.isVisible()) {
@@ -64,15 +64,16 @@ export class MetamaskPage implements WalletPage {
   async cancelAllTxInQueue() {
     await test.step('Force close all transactions', async () => {
       await test.step('Close all extension pages', async () => {
-        const pages = await this.browserContext.pages();
+        const pages = this.browserContext.pages();
         await Promise.all([
           pages.map((page) => {
-            if (page.url().startsWith('chrome-extension://')) page.close();
+            if (page.url().includes(this.config.COMMON.STORE_EXTENSION_ID))
+              page.close();
           }),
         ]);
       });
       await this.initLocators();
-      await this.homePage.openWidgetPage();
+      await this.homePage.openExtensionPage();
       await this.header.appHeaderLogo.waitFor({ state: 'visible' });
       await this.walletOperation.cancelAllTxInQueue(); // reject all tx in queue if exist
       await this.page.close();

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -61,6 +61,23 @@ export class MetamaskPage implements WalletPage {
     });
   }
 
+  async cancelAllTxInQueue() {
+    await test.step('Force close all transactions', async () => {
+      await test.step('Close all extension pages', async () => {
+        const pages = await this.browserContext.pages();
+        await Promise.all([
+          pages.map((page) => {
+            if (page.url().startsWith('chrome-extension://')) page.close();
+          }),
+        ]);
+      });
+      await this.homePage.openWidgetPage();
+      await this.header.appHeaderLogo.waitFor({ state: 'visible' });
+      await this.walletOperation.cancelAllTxInQueue(); // reject all tx in queue if exist
+      await this.page.close();
+    });
+  }
+
   async setup() {
     await test.step('Setup', async () => {
       // added explicit route to #onboarding due to unexpected first time route from /home.html to /onboarding ---> page is close

--- a/packages/wallets/src/metamask/pages/home.page.ts
+++ b/packages/wallets/src/metamask/pages/home.page.ts
@@ -44,7 +44,7 @@ export class HomePage {
     this.importTokenButton = this.page.getByText('import tokens');
   }
 
-  async openWidgetPage() {
+  async openExtensionPage() {
     await this.page.goto(
       this.extensionUrl + this.config.COMMON.EXTENSION_START_PATH,
     );

--- a/packages/wallets/src/wallet.page.ts
+++ b/packages/wallets/src/wallet.page.ts
@@ -17,6 +17,8 @@ export interface WalletPage {
 
   cancelTx?(page: Page): Promise<void>;
 
+  cancelAllTxInQueue?(): Promise<void>;
+
   approveTokenTx?(page: Page): Promise<void>;
 
   openLastTxInEthplorer?(txIndex?: number): Promise<Page>;


### PR DESCRIPTION
Added:

- `cancelAllTxInQueue` - is a method to cancel all transactions in the wallet queue. It can be used in an afterEach hook. Before canceling all transactions, the method will close all pages with the extension URL, as only one page with the extension URL can be open at a time.