### PR TITLE
Change Ubuntu version for CI tests run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test:
     name: Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
- decrease the ubuntu version for CI to 22.04

## Notes:
- the new ubuntu version - 24 - throw the error in the test run 
  - failed test run - https://github.com/lidofinance/wallets-testing-modules/actions/runs/12651166415/job/35251197173)
