### PR TITLE
fix: add param for `latestStableDownloadUrl` to download extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "branches": [
       "main",
       {
-        "name": "develop",
-        "channel": "alpha",
-        "prerelease": "alpha"
+        "name": "add-downloadExtension-concrete-url",
+        "channel": "alpha-downloadExtens",
+        "prerelease": "alpha-downloadExtens"
       }
     ]
   }

--- a/packages/wallets/src/metamask/metamask.constants.ts
+++ b/packages/wallets/src/metamask/metamask.constants.ts
@@ -7,5 +7,7 @@ export const METAMASK_COMMON_CONFIG: CommonWalletConfig = {
   STORE_EXTENSION_ID: 'nkbihfbeogaeaoehlefnkodbefgpgknn',
   CONNECT_BUTTON_NAME: 'MetaMask',
   SIMPLE_CONNECT: false,
+  LATEST_STABLE_DOWNLOAD_LINK:
+    'https://github.com/MetaMask/metamask-extension/releases/download/v12.10.4/metamask-chrome-12.10.4.zip',
   EXTENSION_START_PATH: '/home.html',
 };

--- a/packages/wallets/src/metamask/metamask.page.ts
+++ b/packages/wallets/src/metamask/metamask.page.ts
@@ -2,7 +2,7 @@ import { NetworkConfig, WalletConfig } from '../wallets.constants';
 import { WalletPage } from '../wallet.page';
 import { expect } from '@playwright/test';
 import { test, BrowserContext, Page } from '@playwright/test';
-import { HomePage, LoginPage } from './pages';
+import { HomePage, LoginPage, SettingsPage } from './pages';
 import {
   OnboardingPage,
   WalletOperationPage,
@@ -64,6 +64,11 @@ export class MetamaskPage implements WalletPage {
         await this.onboardingPage.firstTimeSetup();
         await this.popoverElements.closePopover();
         await this.walletOperation.cancelAllTxInQueue(); // reject all tx in queue if exist
+        await new SettingsPage(
+          await this.browserContext.newPage(),
+          this.extensionUrl,
+          this.config,
+        ).setupNetworkChangingSetting(); // need to make it possible to change the wallet network
       }
     });
   }

--- a/packages/wallets/src/metamask/pages/settings.page.ts
+++ b/packages/wallets/src/metamask/pages/settings.page.ts
@@ -37,4 +37,19 @@ export class SettingsPage {
       );
     });
   }
+
+  async setupNetworkChangingSetting() {
+    await test.step('Check toggle state', async () => {
+      await this.openSettings();
+      await this.experimentalTabButton.click();
+      const toggleState =
+        await this.inputNetworksForEachSiteToggle.getAttribute('value');
+
+      if (toggleState === 'true') {
+        await test.step('Turn off the toggle of the setting network changing', async () => {
+          await this.selectNetworksForEachSiteToggle.click();
+        });
+      }
+    });
+  }
 }

--- a/packages/wallets/src/okx/okx.page.ts
+++ b/packages/wallets/src/okx/okx.page.ts
@@ -82,15 +82,9 @@ export class OkxPage implements WalletPage {
   }
 
   /** Checks the is installed the needed network and add new network to wallet (if needed) */
-  async setupNetwork(standConfig: Record<string, any>) {
-    await test.step(`Setup "${standConfig.chainName}" Network`, async () => {
-      await this.addNetwork({
-        chainName: standConfig.chainName,
-        rpcUrl: standConfig.rpcUrl,
-        chainId: standConfig.chainId,
-        tokenSymbol: standConfig.tokenSymbol,
-        scan: standConfig.scan,
-      });
+  async setupNetwork(networkConfig: NetworkConfig) {
+    await test.step(`Setup "${networkConfig.chainName}" Network`, async () => {
+      await this.addNetwork(networkConfig);
     });
   }
 

--- a/packages/wallets/src/wallet.page.ts
+++ b/packages/wallets/src/wallet.page.ts
@@ -29,7 +29,7 @@ export interface WalletPage {
 
   getWalletAddress?(): Promise<string>;
 
-  setupNetwork?(standConfig: Record<string, any>): Promise<void>;
+  setupNetwork?(networkConfig: NetworkConfig): Promise<void>;
 
   addNetwork(
     networkConfig: NetworkConfig,

--- a/packages/wallets/src/wallets.constants.ts
+++ b/packages/wallets/src/wallets.constants.ts
@@ -5,6 +5,7 @@ export interface CommonWalletConfig {
   STORE_EXTENSION_ID: string;
   CONNECT_BUTTON_NAME: string;
   SIMPLE_CONNECT: boolean;
+  // optional stable link for test
   LATEST_STABLE_DOWNLOAD_LINK?: string;
   EXTENSION_START_PATH: string;
 }

--- a/packages/wallets/src/wallets.constants.ts
+++ b/packages/wallets/src/wallets.constants.ts
@@ -5,6 +5,7 @@ export interface CommonWalletConfig {
   STORE_EXTENSION_ID: string;
   CONNECT_BUTTON_NAME: string;
   SIMPLE_CONNECT: boolean;
+  LATEST_STABLE_DOWNLOAD_LINK?: string;
   EXTENSION_START_PATH: string;
 }
 

--- a/wallets-testing/browser/browser.service.ts
+++ b/wallets-testing/browser/browser.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
   CommonWalletConfig,
+  METAMASK_COMMON_CONFIG,
   WalletConfig,
   WalletPage,
 } from '@lidofinance/wallets-testing-wallets';
@@ -81,6 +82,7 @@ export class BrowserService {
     walletConfig.EXTENSION_PATH =
       await this.extensionService.getExtensionDirFromId(
         commonWalletConfig.STORE_EXTENSION_ID,
+        commonWalletConfig.LATEST_STABLE_DOWNLOAD_LINK,
       );
     await this.browserContextService.setup(
       commonWalletConfig.WALLET_NAME,

--- a/wallets-testing/browser/browser.service.ts
+++ b/wallets-testing/browser/browser.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import {
   CommonWalletConfig,
-  METAMASK_COMMON_CONFIG,
   WalletConfig,
   WalletPage,
 } from '@lidofinance/wallets-testing-wallets';


### PR DESCRIPTION
- add ability to pass github link to download concrete version of any wallet.
- Right now `LATEST_STABLE_DOWNLOAD_LINK` stored only for `Metamask`. At this point means that all extensions would be download latest from chrome store,but metamask download from `LATEST_STABLE_DOWNLOAD_LINK`
- downloadUrl - optional param.

## Usage
1) Main call
```
    walletConfig.EXTENSION_PATH =
      await this.extensionService.getExtensionDirFromId(
        commonWalletConfig.STORE_EXTENSION_ID,
        commonWalletConfig.LATEST_STABLE_DOWNLOAD_LINK,
      );
```
2) downloadConcrete version using github store
```
     process.env.EXTENSION_PATH =
        await new ExtensionService().getExtensionDirFromId(
          walletConfig.STORE_EXTENSION_ID,
          // optional param with concrete version via `LATEST_STABLE_DOWNLOAD_LINK`
          walletConfig.LATEST_STABLE_DOWNLOAD_LINK,
        );
        );
```
3) download lattest version using  chrome store
```
      process.env.EXTENSION_PATH =
        await new ExtensionService().getExtensionDirFromId(
          walletConfig.STORE_EXTENSION_ID,
        );
```

4) downloadExtension function
```
  async downloadExtension(id: string, downloadUrl?: string) {
    await this.createBaseExtensionDir();
    if (await this.isExtensionByIdEmpty(id)) {
      const extensionDir = await this.createExtensionDirById(id);
      downloadUrl
        ? await this.downloadFromUrl(id, downloadUrl, extensionDir)
        : await this.downloadFromStore(id, extensionDir);

      if (this.idToExtension[id] !== undefined) {
        this.staleExtensionDirs.push(this.idToExtension[id]);
      }
      this.idToExtension[id] = extensionDir;
    }
    this.idToExtension[id] = `${this.extensionDirBasePath}/${id}`;
  }
  ```