### PR TITLE
change the Discord report msg format

### DIFF
--- a/packages/discord-reporter/src/index.ts
+++ b/packages/discord-reporter/src/index.ts
@@ -31,7 +31,8 @@ type WebhookPayload = {
 
 type ReporterOptions = {
   enabled: string;
-  ciJobName?: string;
+  customTitle?: string;
+  customDescription?: string;
   ciRunUrl?: string;
   discordWebhookUrl: string;
   discordDutyTag?: string;
@@ -90,7 +91,7 @@ class DiscordReporter implements Reporter {
       passed: {
         content: undefined,
         color: GREEN,
-        title: '🎉 Testing Completed!',
+        title: '🧘 Testing Completed!',
       },
       failed: {
         content:
@@ -123,9 +124,9 @@ class DiscordReporter implements Reporter {
           },
         },
       );
-      this.logger.log('Discord message successfully sended:', response.status);
+      this.logger.log(`Discord message successfully sent: ${response.status}`);
     } catch (error: any) {
-      this.logger.error('Error while discord message sended:', error?.message);
+      this.logger.error(`Error while discord message sent: ${error?.message}`);
     }
   }
 
@@ -161,10 +162,13 @@ class DiscordReporter implements Reporter {
       content: this.resultToStatus[result.status].content,
       embeds: [
         {
-          title: this.resultToStatus[result.status].title,
-          description: this.options.ciJobName
-            ? `Test job name: ${this.options.ciJobName}`
-            : 'Here are the test run results:',
+          title: `${this.resultToStatus[result.status].title} ${
+            this.options.customTitle || ''
+          }`,
+          description:
+            (this.options.customDescription ||
+              'Here are the test run results:') +
+            `\n- View [GitHub Run](${this.options.ciRunUrl})`,
           color: this.resultToStatus[result.status].color,
           fields: [
             {
@@ -193,13 +197,6 @@ class DiscordReporter implements Reporter {
               name: '⏳ Run Time',
               value: `${duration}`,
               inline: false,
-            },
-            {
-              name: '🔗 GitHub Run',
-              value: process.env.CI
-                ? `[View GitHub Run](${this.options.ciRunUrl})`
-                : 'Test run',
-              inline: true,
             },
           ],
           url: this.options.ciRunUrl,


### PR DESCRIPTION
## Notes:
- update report msg format to Discord

## Description
- added `customTitle` and `customDescription` params to `discordReporter`
- example on the img below
  - first msg - without `customTitle` and `customDescription`
  - other msgs - with `customTitle` and `customDescription`
- How to Use?  See here -> https://github.com/lidofinance/lido-autotests/pull/242

_p.s. incorrect GitHub link because the local run_
<img width="435" alt="image" src="https://github.com/user-attachments/assets/804468cf-1331-4bf3-b92a-80fb90dd1311" />