### PR TITLE
feat: add reducedMotion options to BrowserContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "branches": [
       "main",
       {
-        "name": "develop",
-        "channel": "alpha",
-        "prerelease": "alpha"
+        "name": "feat/add-reducedMotion",
+        "channel": "alpha-reduceMotion",
+        "prerelease": "alpha-reduceMotion"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "branches": [
       "main",
       {
-        "name": "feat/add-reducedMotion",
-        "channel": "alpha-reduceMotion",
-        "prerelease": "alpha-reduceMotion"
+        "name": "develop",
+        "channel": "alpha",
+        "prerelease": "alpha"
       }
     ]
   }

--- a/packages/browser-service/src/browser.context.service.ts
+++ b/packages/browser-service/src/browser.context.service.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 export type BrowserOptions = {
   locale?: string;
+  reducedMotion?: null | 'reduce' | 'no-preference';
   headless?: boolean;
   slowMo?: number;
   args?: string[];

--- a/packages/wallets/src/EOA/metamask/pages/elements/networkList.element.ts
+++ b/packages/wallets/src/EOA/metamask/pages/elements/networkList.element.ts
@@ -63,7 +63,8 @@ export class NetworkList {
     // or locator used for different MM versions from latest and LATEST_STABLE_DOWNLOAD_LINK
     const modalNetworkEditButton = this.dialogSection
       .getByTestId(`${testIdPrefix}eip155:${hexChainId}`)
-      .or(this.dialogSection.getByTestId(`${testIdPrefix}0x${hexChainId}`));
+      .or(this.dialogSection.getByTestId(`${testIdPrefix}0x${hexChainId}`))
+      .or(this.dialogSection.getByTestId(`${testIdPrefix}eip155:${chainId}`));
     await modalNetworkEditButton.click();
     await this.editNetworkButton.click();
   }

--- a/packages/wallets/src/EOA/metamask/pages/elements/networkList.element.ts
+++ b/packages/wallets/src/EOA/metamask/pages/elements/networkList.element.ts
@@ -62,9 +62,8 @@ export class NetworkList {
     const testIdPrefix = 'network-list-item-options-button-';
     // or locator used for different MM versions from latest and LATEST_STABLE_DOWNLOAD_LINK
     const modalNetworkEditButton = this.dialogSection
-      .getByTestId(`${testIdPrefix}eip155:${hexChainId}`)
-      .or(this.dialogSection.getByTestId(`${testIdPrefix}0x${hexChainId}`))
-      .or(this.dialogSection.getByTestId(`${testIdPrefix}eip155:${chainId}`));
+      .getByTestId(`${testIdPrefix}eip155:${hexChainId}`) // old stable version
+      .or(this.dialogSection.getByTestId(`${testIdPrefix}eip155:${chainId}`)); // new latest version
     await modalNetworkEditButton.click();
     await this.editNetworkButton.click();
   }

--- a/packages/wallets/src/EOA/metamask/pages/elements/networkList.element.ts
+++ b/packages/wallets/src/EOA/metamask/pages/elements/networkList.element.ts
@@ -62,8 +62,8 @@ export class NetworkList {
     const testIdPrefix = 'network-list-item-options-button-';
     // or locator used for different MM versions from latest and LATEST_STABLE_DOWNLOAD_LINK
     const modalNetworkEditButton = this.dialogSection
-      .getByTestId(`${testIdPrefix}eip155:${hexChainId}`) // old stable version
-      .or(this.dialogSection.getByTestId(`${testIdPrefix}eip155:${chainId}`)); // new latest version
+      .getByTestId(`${testIdPrefix}0x${hexChainId}`) // old stable version
+      .or(this.dialogSection.getByTestId(`${testIdPrefix}eip155:${chainId}`)); // new stable version
     await modalNetworkEditButton.click();
     await this.editNetworkButton.click();
   }


### PR DESCRIPTION
🎭 Since we launch the browser context separately, the Playwright config wasn’t applied — meaning the reducedMotion setting wasn’t passed to the browser either. As a result, animations continued to run 😕

🛠️ I’ve added support for passing this option directly into the browser context, so now animations can be properly disabled when needed ✅