### PR TITLE
feat: move pw to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "branches": [
       "main",
       {
-        "name": "develop",
-        "channel": "alpha",
-        "prerelease": "alpha"
+        "name": "feat/use-peer-deps",
+        "channel": "alpha-peed-deps",
+        "prerelease": "alpha-peed-deps"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
     "branches": [
       "main",
       {
-        "name": "feat/use-peer-deps",
-        "channel": "alpha-peed-deps",
-        "prerelease": "alpha-peed-deps"
+        "name": "develop",
+        "channel": "alpha",
+        "prerelease": "alpha"
       }
     ]
   }

--- a/packages/browser-service/package.json
+++ b/packages/browser-service/package.json
@@ -31,7 +31,9 @@
   "dependencies": {
     "@lidofinance/wallets-testing-wallets": "*",
     "@lidofinance/wallets-testing-extensions": "*",
-    "@lidofinance/wallets-testing-nodes": "*",
+    "@lidofinance/wallets-testing-nodes": "*"
+  },
+  "peerDependencies": {
     "@playwright/test": "^1.51.1"
   }
 }

--- a/packages/discord-reporter/package.json
+++ b/packages/discord-reporter/package.json
@@ -29,7 +29,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@playwright/test": "^1.51.1",
     "axios": "^0.30.0"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.51.1"
   }
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -31,12 +31,14 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "axios": "^0.30.0",
-    "@playwright/test": "^1.51.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.6",
     "unzipper": "^0.10.11"
   },
   "devDependencies": {
     "@types/unzipper": "^0.10.5"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.51.1"
   }
 }

--- a/packages/nodes/package.json
+++ b/packages/nodes/package.json
@@ -30,11 +30,13 @@
   },
   "dependencies": {
     "@ganache/console.log": "^0.4.2",
-    "@playwright/test": "^1.51.1",
     "@nestjs/common": "^10.0.0",
     "ethers": "^5.8.0",
     "ganache": "7.9.2",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.6"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.51.1"
   }
 }

--- a/packages/pg-reporter/package.json
+++ b/packages/pg-reporter/package.json
@@ -29,7 +29,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@playwright/test": "^1.51.1",
     "axios": "^0.30.0"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.51.1"
   }
 }

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -29,10 +29,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@playwright/test": "^1.51.1",
     "expect": "^28.1.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.6",
     "viem": "^2.21.40"
+  },
+  "peerDependencies": {
+    "@playwright/test": "^1.51.1"
   }
 }


### PR DESCRIPTION
📦 Moved Playwright to peerDependencies

This update improves version consistency across our repositories by:
- 🔄 Moving Playwright from devDependencies to peerDependencies
- 🧩 Fixing version conflicts when trying to upgrade Playwright in main repos
- 🚫 Preventing duplicate installations that used to cause runtime errors

Thanks to this change, Playwright will now be managed by the main repository, ensuring smoother upgrades and better compatibility ✅