### PR TITLE
feat: implement PgReporter class with metrics tracking and reporting functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "branches": [
       "main",
       {
-        "name": "develop",
-        "channel": "alpha",
-        "prerelease": "alpha"
+        "name": "feat/add-pg-reporter",
+        "channel": "alpha-pg-reporter",
+        "prerelease": "alpha-pg-reporter"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "branches": [
       "main",
       {
-        "name": "feat/add-pg-reporter",
-        "channel": "alpha-pg-reporter",
-        "prerelease": "alpha-pg-reporter"
+        "name": "develop",
+        "channel": "alpha",
+        "prerelease": "alpha"
       }
     ]
   }

--- a/packages/pg-reporter/README.md
+++ b/packages/pg-reporter/README.md
@@ -1,3 +1,3 @@
 # Wallets Module
 
-`@lidofinance/pg-reporter` is a custom Playwright reporter for Pushgateway.
+`@lidofinance/pg-reporter` is a custom Playwright reporter for Pushgateway and Prometheus.

--- a/packages/pg-reporter/package.json
+++ b/packages/pg-reporter/package.json
@@ -29,7 +29,10 @@
     "access": "public"
   },
   "dependencies": {
-    "axios": "^1.10.0"
+    "axios": "^1.10.0",
+    "prom-client": "^15.1.3",
+    "date-fns": "^4.1.0",
+    "uuid": "^13.0.0"
   },
   "peerDependencies": {
     "@playwright/test": "^1.51.1"

--- a/packages/pg-reporter/src/grafanaClient.ts
+++ b/packages/pg-reporter/src/grafanaClient.ts
@@ -1,0 +1,68 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface GrafanaClientOptions {
+  /** Base URL of Grafana, e.g. https://grafana.example.com */
+  baseUrl: string;
+  /** Grafana API key with permissions to create annotations */
+  apiKey: string;
+}
+
+export interface GrafanaAnnotationPayload {
+  /** Epoch milliseconds */
+  time: number;
+  /** Optional time end (range annotation) */
+  timeEnd?: number;
+  /** Tags for filtering/searching */
+  tags?: string[];
+  /** Markdown / text content */
+  text: string;
+  /** Optional dashboard id */
+  dashboardId?: number;
+  /** Optional panel id */
+  panelId?: number;
+}
+
+export interface GrafanaAnnotationResponse {
+  id: number;
+  message?: string;
+}
+
+/** Minimal Grafana API client with only annotation creation */
+export class GrafanaClient {
+  private readonly http: AxiosInstance;
+
+  constructor(private readonly options: GrafanaClientOptions) {
+    this.http = axios.create({
+      baseURL: options.baseUrl.replace(/\/$/, ''),
+      headers: {
+        Authorization: `Bearer ${options.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      timeout: 15_000,
+    });
+  }
+
+  /**
+   * Create annotation in Grafana.
+   */
+  async addAnnotation(
+    payload: GrafanaAnnotationPayload,
+  ): Promise<GrafanaAnnotationResponse> {
+    const body: Record<string, any> = {
+      time: payload.time,
+      text: payload.text,
+    };
+
+    if (payload.timeEnd) body.timeEnd = payload.timeEnd;
+    if (payload.tags?.length) body.tags = payload.tags;
+    if (payload.dashboardId != null) body.dashboardId = payload.dashboardId;
+    if (payload.panelId != null) body.panelId = payload.panelId;
+
+    const { data } = await this.http.post<
+      GrafanaAnnotationResponse | { id: number }
+    >('/api/annotations', body);
+    // Some Grafana versions just return {id}
+    if ('id' in data) return data as GrafanaAnnotationResponse;
+    return data;
+  }
+}

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -1,3 +1,446 @@
-class PgReport {}
+import {
+  Reporter,
+  TestCase,
+  FullResult,
+  FullConfig,
+  TestResult,
+  Suite,
+} from '@playwright/test/reporter';
+import { Counter, Gauge, Histogram, Pushgateway, Registry } from 'prom-client';
+import { v4 as uuidv4 } from 'uuid';
+import * as os from 'os';
+import { format } from 'date-fns';
+import { ConsoleLogger } from '@nestjs/common';
+import { ReporterRuntime } from './reportRuntime';
+import { ReportOptions } from './types';
 
-export default PgReport;
+export default class PgReporter implements Reporter {
+  private reportRuntime: ReporterRuntime;
+
+  // report options
+  private options: ReportOptions;
+  private logger: ConsoleLogger;
+
+  // run properties
+  private startTime: number;
+
+  // pushgateway properties
+  private register: Registry;
+  private pushgateway: Pushgateway<any>;
+  private jobName: string;
+
+  // common labels
+  private projectName: string;
+  private pwVersion: string;
+  private runName: string;
+  private branchName: string;
+
+  // project metrics
+  private successRate: Gauge;
+
+  // suite metrics
+  private suiteTotalGauge: Gauge;
+  private suitePassedGauge: Gauge;
+  private suiteFailedGauge: Gauge;
+  private suiteSkippedGauge: Gauge;
+  private suiteBrokenGauge: Gauge;
+  private suiteSuccessRateGauge: Gauge;
+
+  // test metrics
+  private testDurationHistogram: Histogram;
+  private testDurationGauge: Gauge;
+  private testErrorCounter: Counter;
+
+  // run metrics
+  private testRunDurationGauge: Gauge;
+  private testRunStartTimeGauge: Gauge;
+  private testRunStartEndTimeGauge: Gauge;
+  private runEnvInfoGauge: Gauge;
+  private runInfoGauge: Gauge;
+  private runStatusGauge: Gauge;
+  private runTotalTestGauge: Gauge;
+  private runSuccessGauge: Gauge;
+  private runFailedGauge: Gauge;
+  private runFlakyGauge: Gauge;
+  private runSkippedGauge: Gauge;
+  private runBrokenGauge: Gauge;
+
+  constructor(options: ReportOptions) {
+    this.options = options;
+    this.logger = new ConsoleLogger('pgReport');
+    this.branchName = process.env.CI ? this.getBranchName() : 'local-new';
+    this.reportRuntime = new ReporterRuntime();
+
+    this.register = new Registry();
+    this.jobName = 'widget_pw_metrics';
+    this.initPushgatewayClient();
+
+    this.initSuiteMetrics();
+    this.initRunMetrics();
+    this.initTestMetrics();
+  }
+
+  private getBranchName(): string {
+    const branchName =
+      process.env.GITHUB_HEAD_REF ||
+      process.env.TEST_BRANCH ||
+      process.env.GH_BRANCH_REF_NAME ||
+      'none';
+
+    return branchName.replace('/', '-');
+  }
+
+  private initPushgatewayClient() {
+    const authString = Buffer.from(
+      `${this.options.pushgatewayOptions.username}:${this.options.pushgatewayOptions.password}`,
+    ).toString('base64');
+
+    this.pushgateway = new Pushgateway(
+      this.options.pushgatewayOptions.url,
+      {
+        headers: {
+          authorization: `Basic ${authString}`,
+          cookie: this.options.pushgatewayOptions.cookie,
+        },
+      },
+      this.register,
+    );
+  }
+
+  private initSuiteMetrics() {
+    this.suiteTotalGauge = new Gauge({
+      name: 'test_suite_total',
+      help: 'Total tests in suite',
+      labelNames: ['runName', 'suiteName'],
+      registers: [this.register],
+    });
+
+    this.suitePassedGauge = new Gauge({
+      name: 'test_suite_passed',
+      help: 'Passed tests in suite',
+      labelNames: ['runName', 'suiteName'],
+      registers: [this.register],
+    });
+
+    this.suiteFailedGauge = new Gauge({
+      name: 'test_suite_failed',
+      help: 'Failed tests in suite',
+      labelNames: ['runName', 'suiteName'],
+      registers: [this.register],
+    });
+
+    this.suiteSkippedGauge = new Gauge({
+      name: 'test_suite_skipped',
+      help: 'Skipped tests in suite',
+      labelNames: ['runName', 'suiteName'],
+      registers: [this.register],
+    });
+
+    this.suiteBrokenGauge = new Gauge({
+      name: 'test_suite_broken',
+      help: 'Broken tests in suite',
+      labelNames: ['runName', 'suiteName'],
+      registers: [this.register],
+    });
+
+    this.suiteSuccessRateGauge = new Gauge({
+      name: 'test_suite_success_rate',
+      help: 'Success rate percentage for suite',
+      labelNames: ['runName', 'suiteName'],
+      registers: [this.register],
+    });
+  }
+
+  private initRunMetrics() {
+    // always equal 1
+    this.runStatusGauge = new Gauge({
+      name: 'test_run_status',
+      help: 'Test run status',
+      labelNames: ['runName', 'status'],
+      registers: [this.register],
+    });
+
+    this.runEnvInfoGauge = new Gauge({
+      name: 'test_run_env_info',
+      help: 'Test run env info',
+      labelNames: [
+        'runName',
+        'osName',
+        'osVersion',
+        'nodejsVersion',
+        'pwVersion',
+      ],
+      registers: [this.register],
+    });
+
+    this.runInfoGauge = new Gauge({
+      name: 'test_run_info',
+      help: 'Test run info',
+      labelNames: ['runName', 'githubUrl'],
+      registers: [this.register],
+    });
+
+    this.testRunDurationGauge = new Gauge({
+      name: 'test_run_duration',
+      help: 'test run duration in milliseconds',
+      labelNames: ['runName', 'suiteTag'],
+      registers: [this.register],
+    });
+
+    this.testRunStartTimeGauge = new Gauge({
+      name: 'test_run_start_time',
+      help: 'test run start time in milliseconds',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.testRunStartEndTimeGauge = new Gauge({
+      name: 'test_run_start_end_time_counter',
+      help: 'Test run start and end time counter',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.runTotalTestGauge = new Gauge({
+      name: 'tests_total',
+      help: 'Test run total count',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.runFailedGauge = new Gauge({
+      name: 'tests_failed_total',
+      help: 'Test run failed count',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.runSuccessGauge = new Gauge({
+      name: 'tests_success_total',
+      help: 'Test run success count',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.runFlakyGauge = new Gauge({
+      name: 'tests_flaky_total',
+      help: 'Test run flaky count',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.runSkippedGauge = new Gauge({
+      name: 'tests_skipped_total',
+      help: 'Tests skipped count',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+
+    this.runBrokenGauge = new Gauge({
+      name: 'tests_broken_total',
+      help: 'Tests broken count',
+      labelNames: ['runName'],
+      registers: [this.register],
+    });
+  }
+
+  private initTestMetrics() {
+    this.testDurationGauge = new Gauge({
+      name: 'test_duration',
+      help: 'test duration in milliseconds',
+      labelNames: ['runName', 'testTitle'],
+      registers: [this.register],
+    });
+
+    this.testDurationHistogram = new Histogram({
+      name: 'test_duration_seconds',
+      help: 'Test duration in seconds',
+      buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+      registers: [this.register],
+    });
+
+    this.testErrorCounter = new Counter({
+      name: 'test_error',
+      help: 'Test error messages counter',
+      labelNames: ['runName', 'testTitle', 'errorMessage'],
+      registers: [this.register],
+    });
+  }
+
+  async onBegin(config: FullConfig, suite: Suite) {
+    this.reportRuntime.handleRunBegin(config, suite, {
+      skipProjects: this.options.skipProjects,
+    });
+    this.startTime = Date.now();
+    this.pwVersion = config.version;
+    this.runName = this.getRunName();
+    const rootSuite = suite
+      .entries()
+      .find(
+        (suite) => !this.options.skipProjects.includes(suite.title),
+      ) as Suite;
+    this.projectName = rootSuite.title;
+
+    this.testRunStartTimeGauge.set({ runName: this.runName }, this.startTime);
+
+    this.testRunStartEndTimeGauge.set({ runName: this.runName }, 1);
+    this.runStatusGauge.set(
+      {
+        runName: this.runName,
+        status: 'in progress',
+      },
+      1,
+    );
+    this.runEnvInfoGauge.set(
+      {
+        runName: this.runName,
+        osName: os.type(),
+        osVersion: os.release(),
+        nodejsVersion: process.version,
+        pwVersion: this.pwVersion,
+      },
+      1,
+    );
+    const githubUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+    this.runInfoGauge.set(
+      {
+        runName: this.runName,
+        githubUrl: githubUrl,
+      },
+      1,
+    );
+    this.logger.log(`Initial push of metrics for the run: ${this.runName}`);
+    await this.pushMetricsToPushgateway();
+  }
+
+  onTestBegin(test: TestCase): void {
+    this.reportRuntime.handleTestBegin(test);
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    if (this.options.skipProjects.includes(test.parent.project().name)) {
+      return;
+    }
+
+    this.reportRuntime.handleTestEnd(test, result);
+
+    this.testDurationGauge.set(
+      { runName: this.runName, testTitle: test.title },
+      result.duration,
+    );
+
+    this.testDurationHistogram.observe(result.duration / 1000);
+  }
+
+  setTestsStatusCounters() {
+    const runSummary = this.reportRuntime.getSummary();
+    this.runTotalTestGauge.set({ runName: this.runName }, runSummary.total);
+    this.runSuccessGauge.set({ runName: this.runName }, runSummary.passed);
+    this.runFailedGauge.set({ runName: this.runName }, runSummary.failed);
+    this.runFlakyGauge.set({ runName: this.runName }, runSummary.flaky);
+    this.runSkippedGauge.set({ runName: this.runName }, runSummary.skipped);
+    this.runBrokenGauge.set({ runName: this.runName }, runSummary.broken);
+
+    this.reportRuntime.getFailedTests().forEach((test) => {
+      this.testErrorCounter.inc({
+        runName: this.runName,
+        testTitle: test.title,
+        errorMessage:
+          // eslint-disable-next-line no-control-regex
+          test.error?.replace(/\x1b\[[0-9;]*m/g, '').trim() || 'Unknown error',
+      });
+    });
+  }
+
+  setSuccessRate() {
+    this.successRate = new Gauge({
+      name: 'test_success_rate',
+      help: 'Common success rate by runs for the project',
+      registers: [this.register],
+    });
+    const successRate = this.reportRuntime.getSummary().successRate;
+    this.successRate.set({}, successRate);
+  }
+
+  setSuiteMetrics() {
+    const suites = this.reportRuntime.getAllSuites();
+
+    suites.forEach((suite) => {
+      const labels = {
+        runName: this.runName,
+        suiteName: suite.suiteName,
+      };
+
+      this.suiteTotalGauge.set(labels, suite.total);
+      this.suitePassedGauge.set(labels, suite.passed);
+      this.suiteFailedGauge.set(labels, suite.failed);
+      this.suiteSkippedGauge.set(labels, suite.skipped);
+      this.suiteBrokenGauge.set(labels, suite.broken);
+      this.suiteSuccessRateGauge.set(labels, suite.successRate);
+    });
+  }
+
+  async onEnd(result: FullResult) {
+    this.reportRuntime.handleRunEnd();
+    this.setTestsStatusCounters();
+    this.setSuccessRate();
+    this.setSuiteMetrics();
+
+    this.testRunStartEndTimeGauge.set({ runName: this.runName }, 0);
+
+    const duration = Date.now() - result.startTime.getTime();
+
+    this.testRunDurationGauge.set(
+      {
+        runName: this.runName,
+        suiteTag: `[s:@${process.env.TEST_SUITE || 'All'}] - [t:${
+          process.env.TEST_TAGS || '-'
+        }]`,
+      },
+      duration,
+    );
+
+    this.runStatusGauge.set(
+      {
+        runName: this.runName,
+        status: 'in progress',
+      },
+      0,
+    );
+    this.runStatusGauge.set(
+      {
+        runName: this.runName,
+        status: result.status,
+      },
+      1,
+    );
+
+    await this.pushMetricsToPushgateway();
+  }
+
+  private getRunName() {
+    return process.env.CI
+      ? `[${format(new Date(this.startTime), 'yyyy-MM-dd HH:mm:ss')}]-${
+          this.options.runName
+        }`
+      : `Local run name ${uuidv4()}`;
+  }
+
+  private async pushMetricsToPushgateway() {
+    try {
+      await this.pushgateway.pushAdd({
+        jobName: this.jobName,
+        groupings: {
+          env: this.options.env,
+          projectName: this.projectName || 'undefined project',
+          branchName: this.branchName,
+          network: this.options.network,
+          testTags: this.options.testTags || '-',
+        },
+      });
+      this.logger.log('Metrics pushed successfully');
+    } catch (error) {
+      this.logger.error(`Error pushing metrics: ${error}`);
+    }
+  }
+}

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -221,18 +221,19 @@ export default class PgReporter implements Reporter {
     this.reportRuntime.handleRunBegin(config, suite);
     this.startTime = Date.now();
     this.runName = this.getRunName();
-
-    this.logger.log(`Initial push of metrics for the run: ${this.runName}`);
-    await this.pushMetricsToPushgateway();
   }
 
   onTestBegin(test: TestCase): void {
-    this.rootSuiteName = test.parent.project().name;
-    this.reportRuntime.handleTestBegin(test);
+    const project = test.parent.project();
+    if (project.metadata?.role !== 'hook') {
+      this.rootSuiteName = test.parent.project().name;
+      this.reportRuntime.handleTestBegin(test);
+    }
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
-    if (this.options.skipProjects?.includes(test.parent.project().name)) {
+    const project = test.parent.project();
+    if (project.metadata?.role === 'hook') {
       return;
     }
 

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -29,6 +29,7 @@ export default class PgReporter implements Reporter {
   private register: Registry;
   private pushgateway: Pushgateway<any>;
   private jobName: string;
+  private rootSuiteName: string;
 
   // common labels
   private pwVersion: string;
@@ -258,6 +259,7 @@ export default class PgReporter implements Reporter {
 
   async onBegin(config: FullConfig, suite: Suite) {
     this.reportRuntime.handleRunBegin(config, suite);
+    this.rootSuiteName = suite.suites[0].title;
     this.startTime = Date.now();
     this.pwVersion = config.version;
     this.runName = this.getRunName();
@@ -409,7 +411,7 @@ export default class PgReporter implements Reporter {
 
   private async pushMetricsToPushgateway() {
     if (
-      (!process.env.CI && !this.options.env) ||
+      (process.env.CI && !this.options.env) ||
       !this.options.appName ||
       !this.options.network
     ) {
@@ -428,6 +430,7 @@ export default class PgReporter implements Reporter {
           env: process.env.CI ? this.options.env : 'development',
           appName: this.options.appName,
           network: this.options.network,
+          rootSuite: this.rootSuiteName,
           testTags: this.options.testTags || '-',
         },
       });

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -424,11 +424,21 @@ export default class PgReporter implements Reporter {
 
   private async pushMetricsToPushgateway() {
     try {
+      if (
+        !this.options.env ||
+        !this.options.appName ||
+        !this.options.network ||
+        !this.branchName
+      ) {
+        throw new Error(
+          `Missing required options for Pushgateway: env: ${this.options.env}, appName: ${this.options.appName}, network: ${this.options.network}`,
+        );
+      }
       await this.pushgateway.pushAdd({
         jobName: this.jobName,
         groupings: {
           env: this.options.env,
-          projectName: this.projectName || 'undefined project',
+          projectName: this.options.appName,
           branchName: this.branchName,
           network: this.options.network,
           testTags: this.options.testTags || '-',

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -332,10 +332,11 @@ export default class PgReporter implements Reporter {
     await this.grafanaClient.addAnnotation({
       time: Date.now(),
       tags: [
+        'playwright:tests',
         `app:${this.options.appName}`,
         `env:${this.options.env}`,
         `tag:${this.options.testTags}`,
-        `rootSuite${this.rootSuiteName}`,
+        `rootSuite:${this.rootSuiteName}`,
         `network:${this.options.network}`,
       ],
       text: this.runName,

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -269,17 +269,13 @@ export default class PgReporter implements Reporter {
 
   async onBegin(config: FullConfig, suite: Suite) {
     this.reportRuntime.handleRunBegin(config, suite, {
+      appName: this.options.appName,
       skipProjects: this.options.skipProjects,
     });
     this.startTime = Date.now();
     this.pwVersion = config.version;
     this.runName = this.getRunName();
-    const rootSuite = suite
-      .entries()
-      .find(
-        (suite) => !this.options.skipProjects?.includes(suite.title),
-      ) as Suite;
-    this.projectName = rootSuite.title;
+    this.projectName = this.options.appName;
 
     this.testRunStartTimeGauge.set({ runName: this.runName }, this.startTime);
 

--- a/packages/pg-reporter/src/index.ts
+++ b/packages/pg-reporter/src/index.ts
@@ -277,7 +277,7 @@ export default class PgReporter implements Reporter {
     const rootSuite = suite
       .entries()
       .find(
-        (suite) => !this.options.skipProjects.includes(suite.title),
+        (suite) => !this.options.skipProjects?.includes(suite.title),
       ) as Suite;
     this.projectName = rootSuite.title;
 
@@ -318,7 +318,7 @@ export default class PgReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
-    if (this.options.skipProjects.includes(test.parent.project().name)) {
+    if (this.options.skipProjects?.includes(test.parent.project().name)) {
       return;
     }
 

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -117,7 +117,7 @@ export class ReporterRuntime {
     testCase.error = result.error?.message;
 
     testCase.flakyHistory.push(result.status);
-    testCase.isFlaky = testCase.isFlaky || this.isTestFlaky(testCase);
+    testCase.isFlaky = this.isTestFlaky(testCase);
 
     if (result.status === 'failed' && result.retry === testCase.maxRetries) {
       const errorMessage = result.error?.message || '';

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import {
   FullConfig,
   Suite,
@@ -44,6 +46,7 @@ export interface TestRunSummary {
 export class ReporterRuntime {
   public startTime: number;
   public projectName: string;
+  private pwConfig: FullConfig;
 
   private testCases = new Map<string, TestCaseInfo>();
   private suiteSummaries = new Map<string, SuiteSummary>();
@@ -67,6 +70,7 @@ export class ReporterRuntime {
     this.suiteSummaries.clear();
 
     this.startTime = Date.now();
+    this.pwConfig = config;
 
     // Ищем rootSuite, исключая skipProjects
     const rootSuite = suite
@@ -249,18 +253,12 @@ export class ReporterRuntime {
 
   private extractSuiteName(test: TestCase): string {
     const testPath = test.location?.file || '';
+    const relativePathToTestFile = path.relative(
+      this.pwConfig.rootDir,
+      testPath,
+    );
 
-    if (!testPath) {
-      return test.parent.project().name;
-    }
-
-    const pathParts = testPath.split('/');
-
-    if (pathParts.length > 1) {
-      return pathParts[pathParts.length - 2];
-    }
-
-    return test.parent.project().name;
+    return path.dirname(relativePathToTestFile);
   }
 
   private calculateSuiteSummaries() {

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -43,6 +43,11 @@ export interface TestRunSummary {
   successRate: number;
 }
 
+export interface RunOptions {
+  appName: string;
+  skipProjects?: string[];
+}
+
 export class ReporterRuntime {
   public startTime: number;
   public projectName: string;
@@ -60,11 +65,7 @@ export class ReporterRuntime {
     successRate: 0,
   };
 
-  handleRunBegin(
-    config: FullConfig,
-    suite: Suite,
-    runBeginOptions?: { skipProjects?: string[] },
-  ) {
+  handleRunBegin(config: FullConfig, suite: Suite, options: RunOptions) {
     // Reset for new test run
     this.testCases.clear();
     this.suiteSummaries.clear();
@@ -75,26 +76,9 @@ export class ReporterRuntime {
     // Ищем rootSuite, исключая skipProjects
     const rootSuite = suite
       .entries()
-      .find(
-        (suite) => !runBeginOptions.skipProjects?.includes(suite.title),
-      ) as Suite;
+      .find((suite) => !options.skipProjects?.includes(suite.title)) as Suite;
 
-    if (!rootSuite) {
-      console.warn('No root suite found, using default values');
-      this.projectName = 'unknown';
-      this.summary = {
-        total: 0,
-        passed: 0,
-        failed: 0,
-        skipped: 0,
-        flaky: 0,
-        broken: 0,
-        successRate: 0,
-      };
-      return;
-    }
-
-    this.projectName = rootSuite.title;
+    this.projectName = options.appName;
 
     // Проверяем, что метод allTests существует
     const totalTests =

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -1,0 +1,314 @@
+import {
+  FullConfig,
+  Suite,
+  TestCase,
+  TestResult,
+} from '@playwright/test/reporter';
+
+export interface TestCaseInfo {
+  id: string;
+  title: string;
+  projectName: string;
+  suiteName: string; // Добавляем имя сьюта
+  status: TestResult['status'] | 'broken';
+  duration: number;
+  error?: string;
+  retry: number;
+  maxRetries: number;
+  isFlaky: boolean;
+  flakyHistory: (TestResult['status'] | 'broken')[];
+}
+
+export interface SuiteSummary {
+  suiteName: string;
+  projectName: string;
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  broken: number;
+  successRate: number;
+  duration: number;
+}
+
+export interface TestRunSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  flaky: number;
+  broken: number;
+  successRate: number;
+}
+
+export class ReporterRuntime {
+  public startTime: number;
+  public projectName: string;
+
+  private testCases = new Map<string, TestCaseInfo>();
+  private suiteSummaries = new Map<string, SuiteSummary>();
+  private summary: TestRunSummary = {
+    total: 0,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+    flaky: 0,
+    broken: 0,
+    successRate: 0,
+  };
+
+  handleRunBegin(
+    config: FullConfig,
+    suite: Suite,
+    runBeginOptions?: { skipProjects?: string[] },
+  ) {
+    // Reset for new run
+    this.testCases.clear();
+    this.suiteSummaries.clear();
+
+    this.startTime = Date.now();
+
+    // Ищем rootSuite, исключая skipProjects
+    const rootSuite = suite
+      .entries()
+      .find(
+        (suite) => !runBeginOptions.skipProjects.includes(suite.title),
+      ) as Suite;
+
+    if (!rootSuite) {
+      console.warn('No root suite found, using default values');
+      this.projectName = 'unknown';
+      this.summary = {
+        total: 0,
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        flaky: 0,
+        broken: 0,
+        successRate: 0,
+      };
+      return;
+    }
+
+    this.projectName = rootSuite.title;
+
+    // Проверяем, что метод allTests существует
+    const totalTests =
+      typeof rootSuite.allTests === 'function'
+        ? rootSuite.allTests().length
+        : 0;
+
+    this.summary = {
+      total: totalTests,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      flaky: 0,
+      broken: 0,
+      successRate: 0,
+    };
+  }
+
+  handleTestBegin(test: TestCase) {
+    const suiteName = this.extractSuiteName(test);
+
+    const testCase: TestCaseInfo = {
+      id: test.id,
+      title: test.title,
+      projectName: test.parent.project().name,
+      suiteName: suiteName,
+      status: 'skipped',
+      duration: 0,
+      retry: 0,
+      maxRetries: test.retries,
+      isFlaky: false,
+      flakyHistory: [],
+    };
+
+    this.testCases.set(test.id, testCase);
+  }
+
+  handleTestEnd(test: TestCase, result: TestResult) {
+    const testCase = this.testCases.get(test.id);
+
+    if (!testCase) {
+      console.warn(
+        `Test case with id ${test.id} not found in ReporterRuntime object.`,
+      );
+      return;
+    }
+
+    testCase.status = result.status;
+    testCase.duration = result.duration;
+    testCase.retry = result.retry;
+    testCase.error = result.error?.message;
+
+    testCase.flakyHistory.push(result.status);
+    testCase.isFlaky = testCase.isFlaky || this.isTestFlaky(testCase);
+
+    if (result.status === 'failed' && result.retry === testCase.maxRetries) {
+      const errorMessage = result.error?.message || '';
+      const isBroken = this.isBrokenTest(errorMessage, result);
+      if (isBroken) {
+        testCase.status = 'broken';
+      }
+    }
+  }
+
+  private isTestFlaky(testCase: TestCaseInfo) {
+    const statuses = testCase.flakyHistory.filter(
+      (s): s is TestResult['status'] | 'broken' => Boolean(s),
+    );
+
+    if (statuses.length <= 1) {
+      return false;
+    }
+
+    const uniqueStatuses = new Set(statuses);
+    return uniqueStatuses.size > 1;
+  }
+
+  handleRunEnd() {
+    this.calculateSummary();
+    this.summary.successRate = this.calculateSuccessRate();
+    this.calculateSuiteSummaries();
+  }
+
+  private calculateSummary() {
+    for (const testCase of Array.from(this.testCases.values())) {
+      switch (testCase.status) {
+        case 'passed':
+          this.summary.passed++;
+          break;
+        case 'failed':
+        case 'timedOut':
+          this.summary.failed++;
+          break;
+        case 'skipped':
+        case 'interrupted':
+          this.summary.skipped++;
+          break;
+        case 'broken':
+          this.summary.broken++;
+          break;
+      }
+
+      if (testCase.isFlaky) {
+        this.summary.flaky++;
+      }
+    }
+  }
+
+  private calculateSuccessRate(): number {
+    if (this.summary.total === 0) return 0;
+    return (
+      ((this.summary.passed + this.summary.skipped) / this.summary.total) * 100
+    );
+  }
+
+  getSummary(): TestRunSummary {
+    return this.summary;
+  }
+
+  getFailedTests(): TestCaseInfo[] {
+    return Array.from(this.testCases.values()).filter(
+      (tc) => tc.status === 'failed' || tc.status === 'timedOut',
+    );
+  }
+
+  // Check if test is broken
+  private isBrokenTest(errorMessage: string, result: TestResult): boolean {
+    // Check for hook-related errors
+    const hookErrors = [
+      'beforeEach',
+      'afterEach',
+      'beforeAll',
+      'afterAll',
+      'setup',
+      'teardown',
+      'globalSetup',
+      'globalTeardown',
+    ];
+
+    // Check if error message contains hook or environment errors
+    const isHookError = hookErrors.some((hook) =>
+      errorMessage.toLowerCase().includes(hook.toLowerCase()),
+    );
+
+    // Check if test has hook-related steps that failed
+    const hasHookStepFailure = result.steps?.some((step) => {
+      const stepTitle = step.title.toLowerCase();
+      return (
+        (stepTitle.includes('before') || stepTitle.includes('after')) &&
+        step.error
+      );
+    });
+
+    return isHookError || !!hasHookStepFailure;
+  }
+
+  private extractSuiteName(test: TestCase): string {
+    const testPath = test.location?.file || '';
+
+    if (!testPath) {
+      return test.parent.project().name;
+    }
+
+    const pathParts = testPath.split('/');
+
+    if (pathParts.length > 1) {
+      return pathParts[pathParts.length - 2];
+    }
+
+    return test.parent.project().name;
+  }
+
+  private calculateSuiteSummaries() {
+    const suiteStats = new Map<string, SuiteSummary>();
+
+    Array.from(this.testCases.values()).forEach((testCase) => {
+      const suiteKey = `${testCase.projectName}:${testCase.suiteName}`;
+
+      if (!suiteStats.has(suiteKey)) {
+        suiteStats.set(suiteKey, {
+          suiteName: testCase.suiteName,
+          projectName: testCase.projectName,
+          total: 0,
+          passed: 0,
+          failed: 0,
+          skipped: 0,
+          broken: 0,
+          successRate: 0,
+          duration: Date.now(),
+        });
+      }
+
+      const suite = suiteStats.get(suiteKey)!;
+      suite.total++;
+
+      if (testCase.status === 'passed') suite.passed++;
+      else if (testCase.status === 'failed' || testCase.status === 'timedOut')
+        suite.failed++;
+      else if (
+        testCase.status === 'skipped' ||
+        testCase.status === 'interrupted'
+      )
+        suite.skipped++;
+      else if (testCase.status === 'broken') suite.broken++;
+    });
+
+    suiteStats.forEach((suite) => {
+      suite.successRate =
+        suite.total > 0
+          ? ((suite.passed + suite.skipped) / suite.total) * 100
+          : 0;
+      this.suiteSummaries.set(`${suite.projectName}:${suite.suiteName}`, suite);
+    });
+  }
+
+  getAllSuites(): SuiteSummary[] {
+    return Array.from(this.suiteSummaries.values());
+  }
+}
+
+export const reporterRuntime = new ReporterRuntime();

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -242,7 +242,9 @@ export class ReporterRuntime {
       testPath,
     );
 
-    return path.dirname(relativePathToTestFile);
+    const testsPath = path.dirname(relativePathToTestFile);
+    if (testsPath === '.') return relativePathToTestFile;
+    return testsPath;
   }
 
   private calculateSuiteSummaries() {

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -62,7 +62,7 @@ export class ReporterRuntime {
     suite: Suite,
     runBeginOptions?: { skipProjects?: string[] },
   ) {
-    // Reset for new run
+    // Reset for new test run
     this.testCases.clear();
     this.suiteSummaries.clear();
 

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -282,10 +282,14 @@ export class ReporterRuntime {
     });
 
     suiteStats.forEach((suite) => {
-      suite.successRate =
-        suite.total > 0
-          ? ((suite.passed + suite.skipped) / suite.total) * 100
-          : 0;
+      const { total, passed, skipped } = suite;
+      const effectiveTotal = total - skipped;
+
+      if (effectiveTotal <= 0) {
+        suite.successRate = -1;
+      } else {
+        suite.successRate = (passed / effectiveTotal) * 100;
+      }
       this.suiteSummaries.set(`${suite.projectName}:${suite.suiteName}`, suite);
     });
   }

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -43,14 +43,8 @@ export interface TestRunSummary {
   successRate: number;
 }
 
-export interface RunOptions {
-  appName: string;
-  skipProjects?: string[];
-}
-
 export class ReporterRuntime {
   public startTime: number;
-  public projectName: string;
   private pwConfig: FullConfig;
 
   private testCases = new Map<string, TestCaseInfo>();
@@ -65,7 +59,7 @@ export class ReporterRuntime {
     successRate: 0,
   };
 
-  handleRunBegin(config: FullConfig, suite: Suite, options: RunOptions) {
+  handleRunBegin(config: FullConfig, suite: Suite) {
     // Reset for new test run
     this.testCases.clear();
     this.suiteSummaries.clear();
@@ -73,18 +67,9 @@ export class ReporterRuntime {
     this.startTime = Date.now();
     this.pwConfig = config;
 
-    // Ищем rootSuite, исключая skipProjects
-    const rootSuite = suite
-      .entries()
-      .find((suite) => !options.skipProjects?.includes(suite.title)) as Suite;
-
-    this.projectName = options.appName;
-
     // Проверяем, что метод allTests существует
     const totalTests =
-      typeof rootSuite.allTests === 'function'
-        ? rootSuite.allTests().length
-        : 0;
+      typeof suite.allTests === 'function' ? suite.allTests().length : 0;
 
     this.summary = {
       total: totalTests,

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -72,7 +72,7 @@ export class ReporterRuntime {
     const rootSuite = suite
       .entries()
       .find(
-        (suite) => !runBeginOptions.skipProjects.includes(suite.title),
+        (suite) => !runBeginOptions.skipProjects?.includes(suite.title),
       ) as Suite;
 
     if (!rootSuite) {

--- a/packages/pg-reporter/src/reportRuntime.ts
+++ b/packages/pg-reporter/src/reportRuntime.ts
@@ -67,7 +67,6 @@ export class ReporterRuntime {
     this.startTime = Date.now();
     this.pwConfig = config;
 
-    // Проверяем, что метод allTests существует
     const totalTests =
       typeof suite.allTests === 'function' ? suite.allTests().length : 0;
 

--- a/packages/pg-reporter/src/types.ts
+++ b/packages/pg-reporter/src/types.ts
@@ -1,4 +1,5 @@
 export interface ReportOptions {
+  appName: string;
   env: string;
   runName: string;
   pushgatewayOptions: {

--- a/packages/pg-reporter/src/types.ts
+++ b/packages/pg-reporter/src/types.ts
@@ -10,5 +10,4 @@ export interface ReportOptions {
   };
   network: string;
   testTags?: string;
-  skipProjects?: string[];
 }

--- a/packages/pg-reporter/src/types.ts
+++ b/packages/pg-reporter/src/types.ts
@@ -8,6 +8,10 @@ export interface ReportOptions {
     url: string;
     cookie: string;
   };
+  grafanaOptions: {
+    url: string;
+    apiKey: string;
+  };
   network: string;
   testTags?: string;
 }

--- a/packages/pg-reporter/src/types.ts
+++ b/packages/pg-reporter/src/types.ts
@@ -1,0 +1,13 @@
+export interface ReportOptions {
+  env: string;
+  runName: string;
+  pushgatewayOptions: {
+    username: string;
+    password: string;
+    url: string;
+    cookie: string;
+  };
+  network: string;
+  testTags?: string;
+  skipProjects?: string[];
+}

--- a/packages/pg-reporter/src/utils.ts
+++ b/packages/pg-reporter/src/utils.ts
@@ -1,0 +1,7 @@
+export function toKebab(s: string) {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,6 +1630,11 @@
   dependencies:
     "@octokit/openapi-types" "^23.0.1"
 
+"@opentelemetry/api@^1.4.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
+
 "@paralleldrive/cuid2@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz#7f91364d53b89e2c9cb9e02e8dd0f129e834455f"
@@ -2839,6 +2844,11 @@ binary@~0.3.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
+
 bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -3465,6 +3475,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 dateformat@^3.0.3:
   version "3.0.3"
@@ -7226,6 +7241,14 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+prom-client@^15.1.3:
+  version "15.1.3"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.3.tgz#69fa8de93a88bc9783173db5f758dc1c69fa8fc2"
+  integrity sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
+    tdigest "^0.1.1"
+
 promise-all-reject-late@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz#f8ebf13483e5ca91ad809ccc2fcf25f26f8643c2"
@@ -8063,7 +8086,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8095,7 +8127,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8237,6 +8276,13 @@ tar@^6.1.11, tar@^6.1.13, tar@^6.1.2, tar@^6.2.1:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
 
 temp-dir@^3.0.0:
   version "3.0.0"
@@ -8658,6 +8704,11 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-13.0.0.tgz#263dc341b19b4d755eb8fe36b78d95a6b65707e8"
+  integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -8848,7 +8899,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8861,6 +8912,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Changes Introduced
	•	Grafana annotations: added the ability to publish annotations via the Grafana API, so it’s visible when a particular run was completed.
	•	Label update: renamed projectName → appName to identify our applications as apps instead of projects.
	•	Metrics adaptation for Landing: adjusted metrics to align with the Landing system, where the concept of “projects” is used to distinguish between browser types.
	•	Scheduled runs only: enabled publishing metrics only for tests triggered automatically on schedule. Manual runs will no longer be included.
	•	Cleanup: removed unused metrics.