### PR TITLE
Change Wallet for the internal tests

### DIFF
--- a/.github/workflows/test-connection.yml
+++ b/.github/workflows/test-connection.yml
@@ -51,6 +51,7 @@ jobs:
             xvfb-run --auto-servernum -- yarn test:wallets
         working-directory: wallets-testing
         env:
+          WC_PROJECT_ID: ${{ secrets.WC_PROJECT_ID }}
           RPC_URL_TOKEN: ${{ secrets.RPC_URL_TOKEN }}
           WALLET_SECRET_PHRASE: ${{ secrets.WALLET_SECRET_PHRASE }}
           WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}

--- a/.github/workflows/test-safe-iframe-tx.yml
+++ b/.github/workflows/test-safe-iframe-tx.yml
@@ -64,6 +64,7 @@ jobs:
           fi
         working-directory: wallets-testing
         env:
+          WC_PROJECT_ID: ${{ secrets.WC_PROJECT_ID }}
           RPC_URL_TOKEN: ${{ secrets.RPC_URL_TOKEN }}
           WALLET_SECRET_PHRASE: ${{ secrets.WALLET_SECRET_PHRASE }}
           WALLET_PASSWORD: ${{ secrets.WALLET_PASSWORD }}

--- a/packages/browser-service/src/browser.service.ts
+++ b/packages/browser-service/src/browser.service.ts
@@ -153,6 +153,14 @@ export class BrowserService {
   }
 
   private setWalletPage() {
+    const standConfig = {
+      chainId: this.options.networkConfig.chainId,
+      standUrl: this.options.standUrl,
+      rpcUrl:
+        this.ethereumNodeService?.state?.nodeUrl ||
+        this.options.networkConfig.rpcUrl,
+    };
+
     const buildExtensionWalletPage = () => {
       const extension = new Extension(this.browserContextService.extensionId);
 
@@ -161,15 +169,8 @@ export class BrowserService {
         extensionUrl: extension.url,
         accountConfig: this.options.accountConfig,
         walletConfig: this.options.walletConfig,
+        standConfig,
       });
-    };
-
-    const standConfig = {
-      chainId: this.options.networkConfig.chainId,
-      standUrl: this.options.standUrl,
-      rpcUrl:
-        this.ethereumNodeService?.state?.nodeUrl ||
-        this.options.networkConfig.rpcUrl,
     };
 
     switch (this.options.walletConfig.WALLET_TYPE) {

--- a/packages/nodes/src/ethereum.node.service.ts
+++ b/packages/nodes/src/ethereum.node.service.ts
@@ -345,7 +345,7 @@ export class EthereumNodeService {
     logger.debug(
       `[mockRoute] RPC mocker enabled and uses the ${
         this.state ? 'FORK' : 'ENV'
-      } rpc url.\nRegistered for URL: ${this.options.mockConfig.rpcUrlToMock}.`,
+      } rpc url. (to mock: /${this.options.mockConfig.rpcUrlToMock}/)`,
     );
 
     await contextOrPage.route(

--- a/packages/wallets/src/bitget/bitgetPage.ts
+++ b/packages/wallets/src/bitget/bitgetPage.ts
@@ -95,11 +95,11 @@ export class BitgetPage implements WalletPage {
   }
 
   async setupNetwork() {
-    this.logger.debug('Method "setupNetwork()" not implemented.');
+    this.logger.warn('Method "setupNetwork()" not implemented.');
   }
 
   async changeNetwork() {
-    this.logger.debug('Method "changeNetwork()" not implemented.');
+    this.logger.warn('Method "changeNetwork()" not implemented.');
   }
 
   async addNetwork() {

--- a/packages/wallets/src/coin98/coin98.page.ts
+++ b/packages/wallets/src/coin98/coin98.page.ts
@@ -161,11 +161,11 @@ export class Coin98 implements WalletPage {
   }
 
   async setupNetwork() {
-    this.logger.debug('Method "setupNetwork()" not implemented.');
+    this.logger.warn('Method "setupNetwork()" not implemented.');
   }
 
   async changeNetwork() {
-    this.logger.debug('Method "changeNetwork()" not implemented.');
+    this.logger.warn('Method "changeNetwork()" not implemented.');
   }
 
   async assertReceiptAddress() {

--- a/packages/wallets/src/coinbase/coinbase.page.ts
+++ b/packages/wallets/src/coinbase/coinbase.page.ts
@@ -155,11 +155,11 @@ export class CoinbasePage implements WalletPage {
   }
 
   async setupNetwork() {
-    this.logger.debug('Method "setupNetwork()" not implemented.');
+    this.logger.warn('Method "setupNetwork()" not implemented.');
   }
 
   async changeNetwork() {
-    this.logger.debug('Method "changeNetwork()" not implemented.');
+    this.logger.warn('Method "changeNetwork()" not implemented.');
   }
 
   async cancelTx() {

--- a/packages/wallets/src/ctrl/ctrl.page.ts
+++ b/packages/wallets/src/ctrl/ctrl.page.ts
@@ -75,11 +75,11 @@ export class CtrlPage implements WalletPage {
   }
 
   async setupNetwork() {
-    this.logger.debug('Method "setupNetwork()" not implemented.');
+    this.logger.warn('Method "setupNetwork()" not implemented.');
   }
 
   async changeNetwork() {
-    this.logger.debug('Method "changeNetwork()" not implemented.');
+    this.logger.warn('Method "changeNetwork()" not implemented.');
   }
 
   importKey(): Promise<void> {

--- a/packages/wallets/src/exodus/exodus.page.ts
+++ b/packages/wallets/src/exodus/exodus.page.ts
@@ -89,11 +89,11 @@ export class ExodusPage implements WalletPage {
   }
 
   async setupNetwork() {
-    this.logger.debug('Method "setupNetwork()" not implemented.');
+    this.logger.warn('Method "setupNetwork()" not implemented.');
   }
 
   async changeNetwork() {
-    this.logger.debug('Method "changeNetwork()" not implemented.');
+    this.logger.warn('Method "changeNetwork()" not implemented.');
   }
 
   async signTx() {

--- a/packages/wallets/src/metamask/metamask-latest/pages/settings.page.ts
+++ b/packages/wallets/src/metamask/metamask-latest/pages/settings.page.ts
@@ -62,6 +62,7 @@ export class SettingsPage {
         if (toggleState === 'false') {
           await test.step('Turn on the toggle of the Extension in full size', async () => {
             await this.selectExtensionInFullSizeToggle.click();
+            await this.page.waitForTimeout(1000); // wait for avoid mm error
           });
         }
       }

--- a/packages/wallets/src/safe/pages/setup.page.ts
+++ b/packages/wallets/src/safe/pages/setup.page.ts
@@ -1,6 +1,7 @@
-import { Locator, Page, test } from '@playwright/test';
+import { Locator, Page, test, expect } from '@playwright/test';
 import { WalletPage } from '../../wallet.page';
 import { ConsoleLogger } from '@nestjs/common';
+import { WC_SDK_COMMON_CONFIG } from '../../walletConnect';
 
 export class SetupPage {
   logger = new ConsoleLogger(`Safe. ${SetupPage.name}`);
@@ -104,6 +105,7 @@ export class SetupPage {
       });
 
       await this.safeAccount.click();
+      await this.page.waitForLoadState();
       return this.page.url();
     });
   }
@@ -123,7 +125,7 @@ export class SetupPage {
   }
 
   async connectWalletExtension() {
-    await test.step('Connect MetaMask wallet', async () => {
+    await test.step(`Connect ${this.extensionPage.options.walletConfig.EXTENSION_WALLET_NAME} wallet`, async () => {
       await this.agreeCookiesSetting();
       await this.page.waitForTimeout(2000);
       await this.closeBeamerAnnouncementBanner();
@@ -133,18 +135,15 @@ export class SetupPage {
         return;
       }
 
+      const walletBtnLocator = this.page.getByRole('button', {
+        name: this.extensionPage.options.walletConfig.SAFE_CONNECT_BUTTON_NAME,
+      });
+
       const attempts = 3; // to connect wallet
       for (let attempt = 1; attempt <= attempts; attempt++) {
         await this.connectWalletBtn.click();
 
-        if (
-          await this.waitForVisible(
-            this.page.getByText(
-              this.extensionPage.options.walletConfig.EXTENSION_WALLET_NAME,
-            ),
-            5000,
-          )
-        ) {
+        if (await this.waitForVisible(walletBtnLocator, 5000)) {
           break;
         }
         this.logger.log(`[Attempt ${attempt}] Connect wallet to Safe failed`);
@@ -152,12 +151,17 @@ export class SetupPage {
       }
 
       try {
-        await this.page
-          .getByText(
-            this.extensionPage.options.walletConfig.EXTENSION_WALLET_NAME,
-          )
-          .click();
-        await this.extensionPage.connectWallet();
+        await walletBtnLocator.click();
+
+        if (
+          this.extensionPage.options.walletConfig.EXTENSION_WALLET_NAME ==
+          WC_SDK_COMMON_CONFIG.WALLET_NAME
+        ) {
+          const qrUri = await this.getWcConnectionUri();
+          await this.extensionPage.connectWallet(qrUri);
+        } else {
+          await this.extensionPage.connectWallet();
+        }
       } catch (er) {
         // Expect the wallet is connected
       }
@@ -180,5 +184,27 @@ export class SetupPage {
     } catch {
       return false;
     }
+  }
+
+  private async getWcConnectionUri() {
+    const wcUriCopyBtn = this.page
+      .locator('.wcm-card')
+      .locator('button[class="wcm-action-btn"]');
+    await wcUriCopyBtn.waitFor({ state: 'visible', timeout: 15000 });
+
+    await expect
+      .poll(
+        async () => {
+          await wcUriCopyBtn.click();
+          return await this.page.evaluate(() => navigator.clipboard.readText());
+        },
+        {
+          timeout: 15000,
+          intervals: [2000],
+        },
+      )
+      .toContain('wc:');
+
+    return await this.page.evaluate(() => navigator.clipboard.readText());
   }
 }

--- a/packages/wallets/src/safe/pages/setup.page.ts
+++ b/packages/wallets/src/safe/pages/setup.page.ts
@@ -211,7 +211,7 @@ export class SetupPage {
           intervals: [2000],
         },
       )
-      .toContain('wc:');
+      .toMatch(/wc:.+/);
 
     return await this.page.evaluate(() => navigator.clipboard.readText());
   }

--- a/packages/wallets/src/safe/pages/setup.page.ts
+++ b/packages/wallets/src/safe/pages/setup.page.ts
@@ -104,9 +104,17 @@ export class SetupPage {
         }
       });
 
+      const accountUrl =
+        await test.step('Extract account url from button', async () => {
+          const accountBtnUrl = await this.safeAccount
+            .getByRole('link')
+            .getAttribute('href');
+          return new URL(this.page.url()).origin + accountBtnUrl;
+        });
+
       await this.safeAccount.click();
       await this.page.waitForLoadState();
-      return this.page.url();
+      return accountUrl;
     });
   }
 

--- a/packages/wallets/src/safe/safe.constants.ts
+++ b/packages/wallets/src/safe/safe.constants.ts
@@ -1,12 +1,13 @@
 import { CommonWalletConfig, WalletConnectTypes } from '../wallets.constants';
-import { METAMASK_COMMON_CONFIG } from '../metamask';
+import { WC_SDK_COMMON_CONFIG } from '../walletConnect';
 
 export const WC_SAFE_COMMON_CONFIG: CommonWalletConfig = {
   WALLET_NAME: 'safeWc',
-  EXTENSION_WALLET_NAME: METAMASK_COMMON_CONFIG.EXTENSION_WALLET_NAME,
+  EXTENSION_WALLET_NAME: WC_SDK_COMMON_CONFIG.WALLET_NAME,
   CONNECTED_WALLET_NAME: 'WalletConnect',
-  STORE_EXTENSION_ID: 'nkbihfbeogaeaoehlefnkodbefgpgknn',
+  STORE_EXTENSION_ID: null,
   CONNECT_BUTTON_NAME: 'WalletConnect',
+  SAFE_CONNECT_BUTTON_NAME: 'WalletConnect',
   WALLET_TYPE: WalletConnectTypes.WC_EOA,
   LATEST_STABLE_DOWNLOAD_LINK: null,
   EXTENSION_START_PATH: '/home.html',
@@ -14,10 +15,11 @@ export const WC_SAFE_COMMON_CONFIG: CommonWalletConfig = {
 
 export const IFRAME_SAFE_COMMON_CONFIG: CommonWalletConfig = {
   WALLET_NAME: 'safeIframe',
-  EXTENSION_WALLET_NAME: METAMASK_COMMON_CONFIG.EXTENSION_WALLET_NAME,
+  EXTENSION_WALLET_NAME: WC_SDK_COMMON_CONFIG.WALLET_NAME,
   CONNECTED_WALLET_NAME: 'Safe',
-  STORE_EXTENSION_ID: 'nkbihfbeogaeaoehlefnkodbefgpgknn',
+  STORE_EXTENSION_ID: null,
   CONNECT_BUTTON_NAME: '', // auto connection
+  SAFE_CONNECT_BUTTON_NAME: 'WalletConnect',
   WALLET_TYPE: WalletConnectTypes.IFRAME,
   LATEST_STABLE_DOWNLOAD_LINK: null,
   EXTENSION_START_PATH: '/home.html',

--- a/packages/wallets/src/walletConnect/components/accounts.ts
+++ b/packages/wallets/src/walletConnect/components/accounts.ts
@@ -1,7 +1,4 @@
-import { ConsoleLogger } from '@nestjs/common';
 import { Account } from 'viem';
-
-const logger = new ConsoleLogger('WCWallet.Accounts');
 
 export class Accounts {
   private activeAccount: Account;
@@ -13,9 +10,7 @@ export class Accounts {
 
   setActiveAccount(account: Account) {
     if (!this.accountsStore.has(account.address.toLowerCase())) {
-      logger.warn(
-        `Account ${account.address} not found in accounts list while setting active account, adding it to accounts list`,
-      );
+      // Account ${account.address} not found in accounts list while setting active account, adding it to accounts list
       this.storeAccount(account);
     }
     this.activeAccount = account;

--- a/packages/wallets/src/walletConnect/components/network.ts
+++ b/packages/wallets/src/walletConnect/components/network.ts
@@ -92,7 +92,6 @@ export class NetworkSettings {
     const networkConfig = this.networksByChainId.get(chainId);
 
     if (chainId === this.activeChainId) {
-      logger.log(`Network "${networkName}" is already active`);
       return SUPPORTED_CHAINS[chainId] ?? buildChainFromNetwork(networkConfig);
     }
 

--- a/packages/wallets/src/walletConnect/components/requestManager.ts
+++ b/packages/wallets/src/walletConnect/components/requestManager.ts
@@ -55,16 +55,8 @@ export class RequestManager {
     return this.pendings[0] || this.nextRequest();
   }
 
-  getTx(req: WCSessionRequest, index = 0): any {
-    return req.params?.request?.params?.[index];
-  }
-
-  getRequestInfo(req) {
-    const tx = this.getTx(req);
-    return {
-      method: req.params.request.method,
-      params: tx,
-    };
+  getRequestInfo(req: WCSessionRequest) {
+    return req.params.request;
   }
 
   resolveRequest(req: WCSessionRequest) {

--- a/packages/wallets/src/walletConnect/constants.ts
+++ b/packages/wallets/src/walletConnect/constants.ts
@@ -37,7 +37,6 @@ export const WC_SDK_COMMON_CONFIG: CommonWalletConfig = {
   WALLET_TYPE: WalletConnectTypes.WC_SDK,
   LATEST_STABLE_DOWNLOAD_LINK: null,
   EXTENSION_START_PATH: null,
-  WC_PROJECT_ID: process.env.WC_PROJECT_ID,
 };
 
 export const SUPPORTED_CHAINS: Record<number, Chain> = {

--- a/packages/wallets/src/walletConnect/methods/eth_signTypedData_v4.ts
+++ b/packages/wallets/src/walletConnect/methods/eth_signTypedData_v4.ts
@@ -8,6 +8,20 @@ export async function eth_signTypedData_v4(
   const typed = req.params.request.params[1];
   const typedData = typeof typed === 'string' ? JSON.parse(typed) : typed;
 
+  const primaryType = typedData.primaryType;
+  const typeFields: { name: string; type: string }[] =
+    typedData.types[primaryType] ?? [];
+
+  const message = Object.fromEntries(
+    Object.entries(typedData.message).map(([key, val]) => {
+      const field = typeFields.find((f) => f.name === key);
+      if (field && /^uint\d*$|^int\d*$/.test(field.type)) {
+        return [key, BigInt(val as string)];
+      }
+      return [key, val];
+    }),
+  );
+
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const signature = await this.walletClient.signTypedData({
@@ -18,12 +32,7 @@ export async function eth_signTypedData_v4(
     },
     types: typedData.types,
     primaryType: typedData.primaryType,
-    message: {
-      ...typedData.message,
-      value: BigInt(typedData.message.value),
-      nonce: BigInt(typedData.message.nonce),
-      deadline: BigInt(typedData.message.deadline),
-    },
+    message,
   });
 
   await this.signClient.respond({

--- a/packages/wallets/src/walletConnect/wc.service.ts
+++ b/packages/wallets/src/walletConnect/wc.service.ts
@@ -58,6 +58,7 @@ export class WCWallet implements WalletPage {
   private networkSettings: NetworkSettings;
   private requestManager: RequestManager;
   protected accounts: Accounts;
+  private projectId: string;
 
   constructor(public options: WalletPageOptions) {
     this.defaultTimeoutMs = 30000;
@@ -76,6 +77,9 @@ export class WCWallet implements WalletPage {
         events: ['accountsChanged', 'chainChanged'],
       },
     };
+    this.projectId = process.env.WC_PROJECT_ID;
+    if (!this.projectId)
+      logger.error('WC_PROJECT_ID is not defined in the env');
   }
 
   private async onSessionRequest(event: any) {
@@ -103,10 +107,7 @@ export class WCWallet implements WalletPage {
 
     await test.step('Setup wallet', async () => {
       if (this.signClient) return;
-
-      this.signClient = await SignClient.init({
-        projectId: this.options.walletConfig.WC_PROJECT_ID,
-      });
+      this.signClient = await SignClient.init({ projectId: this.projectId });
 
       this.networkSettings = new NetworkSettings(this.signClient, account);
       this.requestManager = new RequestManager();
@@ -360,16 +361,25 @@ export class WCWallet implements WalletPage {
   async assertTxAmount(expectedAmount: string): Promise<void> {
     await test.step(`Assert transaction amount ${expectedAmount} ETH`, async () => {
       const request = await this.requestManager.getCurrentRequest();
-      expect(
-        request,
-        'Not found pending request for check transaction amount',
-      ).not.toBeUndefined();
+      expect(request, 'The request must not be undefined').not.toBeUndefined();
 
       const requestInfo = this.requestManager.getRequestInfo(request);
-
-      if (requestInfo.method === 'eth_sendTransaction') {
-        const txAmount = formatEther(BigInt(requestInfo.params.value));
-        expect(txAmount).toEqual(expectedAmount);
+      switch (requestInfo.method) {
+        case 'eth_sendTransaction': {
+          const txAmount = formatEther(BigInt(requestInfo.params[0].value));
+          expect(txAmount).toEqual(expectedAmount);
+          break;
+        }
+        case 'eth_signTypedData_v4': {
+          const paramJson = JSON.parse(requestInfo.params[1]);
+          const txAmount = formatEther(BigInt(paramJson.message.sellAmount));
+          expect(txAmount).toEqual(expectedAmount);
+          break;
+        }
+        default:
+          logger.error(
+            `${requestInfo.method} is not defined to check tx amount`,
+          );
       }
     });
   }
@@ -377,16 +387,27 @@ export class WCWallet implements WalletPage {
   async assertReceiptAddress(expectedAddress: string): Promise<void> {
     await test.step(`Assert transaction receipt address ${expectedAddress}`, async () => {
       const request = await this.requestManager.getCurrentRequest();
-      expect(
-        request,
-        'Not found pending request for check transaction receipt address',
-      ).not.toBeUndefined();
+      expect(request, 'The request must not be undefined').not.toBeUndefined();
 
       const requestInfo = this.requestManager.getRequestInfo(request);
-      if (requestInfo.method === 'eth_sendTransaction') {
-        expect(requestInfo.params.to.toLowerCase()).toEqual(
-          expectedAddress.toLowerCase(),
-        );
+      switch (requestInfo.method) {
+        case 'eth_sendTransaction': {
+          expect(requestInfo.params[0].to.toLowerCase()).toEqual(
+            expectedAddress.toLowerCase(),
+          );
+          break;
+        }
+        case 'eth_signTypedData_v4': {
+          const paramJson = JSON.parse(requestInfo.params[1]);
+          expect(paramJson.domain.verifyingContract).toEqual(
+            expectedAddress.toLowerCase(),
+          );
+          break;
+        }
+        default:
+          logger.error(
+            `${requestInfo.method} is not defined to check tx address`,
+          );
       }
     });
   }

--- a/packages/wallets/src/wallets.constants.ts
+++ b/packages/wallets/src/wallets.constants.ts
@@ -13,12 +13,11 @@ export interface CommonWalletConfig {
   EXTENSION_WALLET_NAME: string; // Wallet name for install extension
   CONNECTED_WALLET_NAME: string; // Displayed name of connected wallet
   CONNECT_BUTTON_NAME: string; // Button name in the wallet list
+  SAFE_CONNECT_BUTTON_NAME?: string; // Button name to connect wallet in the Safe UI
   STORE_EXTENSION_ID: string;
   WALLET_TYPE: WalletConnectType;
   LATEST_STABLE_DOWNLOAD_LINK?: string; // Link to stable wallet extension version for test (optional)
   EXTENSION_START_PATH?: string; // Start path for wallet setup
-  // Only for WC_SDK wallets via API @walletconnect/sign-client
-  WC_PROJECT_ID?: string; // WalletConnect Cloud project ID
 }
 
 export enum WalletConnectTypes {

--- a/wallets-testing/.env.sample
+++ b/wallets-testing/.env.sample
@@ -14,3 +14,6 @@ DISCORD_DUTY_TAG=
 # Slack reporter settings
 SLACK_WEBHOOK_URL=
 SLACK_DUTY_TAG=
+
+# WalletConnect setup
+WC_PROJECT_ID=

--- a/wallets-testing/pages/standWidget.page.ts
+++ b/wallets-testing/pages/standWidget.page.ts
@@ -95,8 +95,8 @@ export class StandWidgetPage implements WidgetPage {
           .poll(
             async () => {
               await this.copyWcUrlBtn.click();
-              return await this.walletPage.connectWallet(
-                await this.page.evaluate(() => navigator.clipboard.readText()),
+              return await this.page.evaluate(() =>
+                navigator.clipboard.readText(),
               );
             },
             {
@@ -106,7 +106,6 @@ export class StandWidgetPage implements WidgetPage {
           )
           .toMatch(/wc:.+/);
 
-        await this.copyWcUrlBtn.click();
         await this.walletPage.connectWallet(
           await this.page.evaluate(() => navigator.clipboard.readText()),
         );

--- a/wallets-testing/pages/standWidget.page.ts
+++ b/wallets-testing/pages/standWidget.page.ts
@@ -1,4 +1,4 @@
-import { Locator, Page, test } from '@playwright/test';
+import { expect, Locator, Page, test } from '@playwright/test';
 import { WidgetPage } from './widget.page';
 import { BrowserService } from '@lidofinance/browser-service';
 import {
@@ -91,6 +91,21 @@ export class StandWidgetPage implements WidgetPage {
         await this.page
           .getByTestId('wui-qr-code')
           .waitFor({ state: 'visible' });
+        await expect
+          .poll(
+            async () => {
+              await this.copyWcUrlBtn.click();
+              return await this.walletPage.connectWallet(
+                await this.page.evaluate(() => navigator.clipboard.readText()),
+              );
+            },
+            {
+              timeout: 15000,
+              intervals: [2000],
+            },
+          )
+          .toMatch(/wc:.+/);
+
         await this.copyWcUrlBtn.click();
         await this.walletPage.connectWallet(
           await this.page.evaluate(() => navigator.clipboard.readText()),

--- a/wallets-testing/playwright.config.ts
+++ b/wallets-testing/playwright.config.ts
@@ -25,6 +25,7 @@ const config: PlaywrightTestConfig = {
   reporter: new ReportersSettings(wtmReporter).getReporters(),
   use: {
     actionTimeout: 120000,
+    permissions: ['clipboard-read', 'clipboard-write'],
     screenshot: { fullPage: true, mode: 'only-on-failure' },
     trace: 'on-first-retry',
   },

--- a/wallets-testing/test/widgets/connection.spec.ts
+++ b/wallets-testing/test/widgets/connection.spec.ts
@@ -75,14 +75,14 @@ test.describe('Ethereum', () => {
     await connectWallet(browserService);
   });
 
-  test('WC_EOA+Safe connect (with MM)', async () => {
+  test('WC_SDK+Safe connect', async () => {
     browserService = await initBrowserWithExtension({
       walletConfig: WC_SAFE_COMMON_CONFIG,
     });
     await connectWallet(browserService);
   });
 
-  test('Safe IframeApp connect (with MM)', async () => {
+  test('Safe IframeApp connect (with WC_SDK)', async () => {
     browserService = await initBrowserWithExtension({
       walletConfig: IFRAME_SAFE_COMMON_CONFIG,
     });


### PR DESCRIPTION
## Notes
- changed the wallet for the internal tests of Safe wallet (`MM` -> `WC_SDK`)
- fixed tx confirmation for the `WC_SDK` wallet for the `eth_signTypedData_v4` event method
- improved `WC_SDK` method to assert transaction data (_contract address and amount_)